### PR TITLE
V0.3

### DIFF
--- a/scripts/load_motion_from_files.py
+++ b/scripts/load_motion_from_files.py
@@ -4,9 +4,7 @@ import mlp.utils.plot as plot
 import multicontact_api
 from multicontact_api import ContactSequenceHumanoid
 import mlp.viewer.display_tools as display_tools
-from hpp.gepetto import Viewer,ViewerFactory
 from hpp.corbaserver.rbprm.rbprmfullbody import FullBody
-from hpp.corbaserver import ProblemSolver
 import time
 import os
 class Robot (FullBody):
@@ -23,14 +21,7 @@ class Robot (FullBody):
             self.loadFullBodyModel(self.urdfName, self.rootJointType, self.meshPackageName, self.packageName, self.urdfSuffix, self.srdfSuffix)
         if name != None:
             self.name = name
-            
-def initScene(envName = "multicontact/ground"):
-    fullBody = Robot ()
-    ps = ProblemSolver(fullBody)
-    vf = ViewerFactory (ps)
-    vf.loadObstacleModel ("hpp_environments", envName, "planning")
-    v = vf.createViewer( displayCoM = True)    
-    return v,fullBody
+
             
 def loadMotionFromFiles(v,path,npzFilename,csFilename):
     # load cs from file : 
@@ -58,16 +49,14 @@ os.system('gepetto-gui &>/dev/null 2>&1')
 os.system('hpp-rbprm-server &>/dev/null 2>&1')
 time.sleep(2)
 
-v,fb = initScene()
+v,fb = display_tools.initScene(Robot)
 path = "/local/dev_hpp/src/multicontact-locomotion-planning/res/"
 npzFile = "export/npz/talos_flatGround.npz"
 csFile = "contact_sequences/talos_flatGround_COM.xml"
 res,cs = loadMotionFromFiles(v,path,npzFile,csFile)
 
 def dispCS(step = 0.2): 
-    for p in cs.contact_phases:
-        display_tools.displayWBconfig(v,p.reference_configurations[0])
-        time.sleep(step)
+    display_tools.displayContactSequence(v,cs,step)
      
 def dispWB():
     display_tools.displayWBmotion(v,res.q_t,res.dt,0.05)

--- a/scripts/load_motion_from_files.py
+++ b/scripts/load_motion_from_files.py
@@ -49,7 +49,7 @@ os.system('gepetto-gui &>/dev/null 2>&1')
 os.system('hpp-rbprm-server &>/dev/null 2>&1')
 time.sleep(2)
 
-v,fb = display_tools.initScene(Robot)
+fb,v = display_tools.initScene(Robot)
 path = "/local/dev_hpp/src/multicontact-locomotion-planning/res/"
 npzFile = "export/npz/talos_flatGround.npz"
 csFile = "contact_sequences/talos_flatGround_COM.xml"

--- a/scripts/mlp/centroidal/__init__.py
+++ b/scripts/mlp/centroidal/__init__.py
@@ -1,0 +1,36 @@
+import mlp.config as cfg 
+
+#centroidal_initGuess_method_available = ["none", "geometric", "croc", "timeopt", "quasistatic"]
+#centroidal_method_available = ["load", "geometric", "croc", "timeopt", "quasistatic", "muscod"]
+
+method_initGuess = cfg.centroidal_initGuess_method
+method = cfg.centroidal_method
+
+if method_initGuess == "none":
+    def generateCentroidalInitGuess(cs,cs_initGuess = None,fullBody=None, viewer =None):
+        return None
+elif method_initGuess == "geometric":
+    from .geometric import generateCentroidalTrajectory as generateCentroidalInitGuess
+elif method_initGuess == "croc":
+    from .croc import generateCentroidalTrajectory as generateCentroidalInitGuess
+elif method_initGuess == "timeopt":
+    from .topt import generateCentroidalTrajectory as generateCentroidalInitGuess
+elif method_initGuess == "quasistatic":
+    from .quasiStatic import generateCentroidalTrajectory as generateCentroidalInitGuess    
+else : 
+    raise ValueError("method type "+str(method)+" doesn't exist for centroidal initGuess")
+
+if method == "load":
+    from .fromCSCOMfile import generateCentroidalTrajectory
+elif method == "geometric":
+    from .geometric import generateCentroidalTrajectory
+elif method == "croc":
+    from .croc import generateCentroidalTrajectory 
+elif method == "timeopt":
+    from .topt import generateCentroidalTrajectory 
+elif method == "quasistatic":
+    from .quasiStatic import generateCentroidalTrajectory  
+elif method == "muscod":
+    from .muscod import generateCentroidalTrajectory    
+else : 
+    raise ValueError("method type "+str(method)+" doesn't exist for centroidal trajectory generation")

--- a/scripts/mlp/centroidal/croc.py
+++ b/scripts/mlp/centroidal/croc.py
@@ -3,7 +3,7 @@ import mlp.config as cfg
 import multicontact_api 
 from multicontact_api import WrenchCone,SOC6,ContactPatch, ContactPhaseHumanoid, ContactSequenceHumanoid
 from hpp_spline import bezier
- 
+from mlp.utils.util import createStateFromPhase, phasesHaveSameConfig
 
 def initGuessForPhaseFromBezier(phase,c,current_t,start,end,append = False):
     from spline import bezier    

--- a/scripts/mlp/centroidal/croc.py
+++ b/scripts/mlp/centroidal/croc.py
@@ -5,8 +5,7 @@ from multicontact_api import WrenchCone,SOC6,ContactPatch, ContactPhaseHumanoid,
 from hpp_spline import bezier
 from mlp.utils.util import createStateFromPhase, phasesHaveSameConfig
 
-def initGuessForPhaseFromBezier(phase,c,current_t,start,end,append = False):
-    from spline import bezier    
+def writeTrajInPhase(phase,c,current_t,start,end,append = False):
     #print "start = ",start
     assert start >= 0 and start < c.max(), "t start invalid"
     #print "end = ",end
@@ -50,48 +49,69 @@ def initGuessForPhaseFromBezier(phase,c,current_t,start,end,append = False):
         t += cfg.SOLVER_DT
         if t > c.max():
             t = c.max() # may happend due to numerical imprecisions
+
+
             
 def createFullbodyStatesFromCS(cs,fb):
-    raise NotImplemented("TODO")
+    phase_prev = cs.contact_phases[0]
+    beginId = createStateFromPhase(fb,phase_prev)
+    lastId = beginId
+    for phase in cs.contact_phases[1:] : 
+        if not phasesHaveSameConfig(phase_prev,phase):
+            lastId = createStateFromPhase(fb,phase)
+            phase_prev = phase
+    return beginId, lastId
 
-        
+# Not generic .... assume that there is always 2 contact phases for each state in fullBody        
 def generateCentroidalTrajectory(cs,cs_initGuess = None, fb = None, viewer = None):
     if cs_initGuess :
         print "WARNING : in centroidal.croc, initial guess is ignored."
     if not fb : 
         raise ValueError("CROC called without fullBody object.")
     beginId,endId = createFullbodyStatesFromCS(cs,fb)
+    print "beginid = ",beginId
+    print "endId   = ",endId
     cs_result = ContactSequenceHumanoid(cs)
+    if (2*(endId - beginId)+1) != cs.size():
+        raise NotImplemented("Current implementation of CROC require to have 2 contact phases per States in fullBody")
     # for each phase in the cs, create a corresponding FullBody State and call CROC,
     # then discretize the solution and fill the cs struct
     # Make the assumption that the CS was created with the generateContactSequence method from the same fb object
+    id_phase = 0 
     for id_state in range(beginId,endId):
-        #print "id_state = ",str(id_state)
+        print "id_state = ",str(id_state)
+        print "id_phase = ",str(id_phase)
+        # First, compute the bezier curves between the states : 
         pid = fb.isDynamicallyReachableFromState(id_state,id_state+1,True,numPointsPerPhases=0)
         if len(pid) != 4:
-            print "Cannot compute qp initial guess for state "+str(id_state)
+            print "# ERROR : Cannot compute CROC between states "+str(id_state)+" , "+str(id_state+1)
             return cs
-        if id_state == 0:
+        c = fb.getPathAsBezier(int(pid[0]))
+        # Now split and write the results in the correct contactPhases
+        if id_phase == 0:
             append = False
             t =0.
         else :
             append = True
-            t = cs_result.contact_phases[id_state*2].time_trajectory[-1]
-        c = fb.getPathAsBezier(int(pid[0]))
-        assert c.min() == 0 ,"bezier curve should start at t=0."     
+            t = cs_result.contact_phases[id_phase].time_trajectory[-1]        
+        assert c.min() == 0 ,"bezier curve should start at t=0."  
+        # First phase (second half of the trajectory of this phase if it's not the initial phase of the CS)        
         start = 0
         end = fb.client.problem.pathLength(int(pid[1]))
-        #print "first DS phase"
-        initGuessForPhaseFromBezier(cs_result.contact_phases[id_state*2], c,t,start,end,append)
+        writeTrajInPhase(cs_result.contact_phases[id_phase], c,t,start,end,append)
+        #Second phase
+        id_phase += 1 
         start = end
         end += fb.client.problem.pathLength(int(pid[2]))
-        #print " SS phase"
-        initGuessForPhaseFromBezier(cs_result.contact_phases[id_state*2+1], c,cs_result.contact_phases[id_state*2].time_trajectory[-1],start,end)
+        t = cs_result.contact_phases[id_phase-1].time_trajectory[-1]        
+        writeTrajInPhase(cs_result.contact_phases[id_phase], c,t,start,end)
+        # Third phase (only the first half of the trajectory, exept if it's the final contact phase of the CS)
+        id_phase += 1 
         start = end
         end += fb.client.problem.pathLength(int(pid[3])) 
+        t = cs_result.contact_phases[id_phase-1].time_trajectory[-1]
         assert abs(end - c.max()) < 1e-10 ,"Error in computation of time interval"
-        #print "second DS phase"        
-        initGuessForPhaseFromBezier(cs_result.contact_phases[id_state*2+2], c,cs_result.contact_phases[id_state*2+1].time_trajectory[-1],start,end)
+        writeTrajInPhase(cs_result.contact_phases[id_phase], c,t,start,end)
         
     return cs_result
      

--- a/scripts/mlp/centroidal/fromCSCOMfile.py
+++ b/scripts/mlp/centroidal/fromCSCOMfile.py
@@ -1,0 +1,9 @@
+import mlp.config as cfg
+from multicontact_api import ContactSequenceHumanoid
+
+def generateCentroidalTrajectory(cs,cs_initGuess = None, fullBody = None, viewer = None):
+    cs_res = ContactSequenceHumanoid(0)
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM.cs"
+    cs_res.loadFromBinary(filename) 
+    print "Import contact sequence binary file : ",filename    
+    return cs_res

--- a/scripts/mlp/centroidal/muscod.py
+++ b/scripts/mlp/centroidal/muscod.py
@@ -1,0 +1,4 @@
+import mlp.config as cfg
+
+def generateCentroidalTrajectory(cs,cs_initGuess = None,fullBody=None, viewer =None):
+    raise NotImplemented("TODO")

--- a/scripts/mlp/centroidal/quasiStatic.py
+++ b/scripts/mlp/centroidal/quasiStatic.py
@@ -1,0 +1,4 @@
+import mlp.config as cfg
+
+def generateCentroidalTrajectory(cs,cs_initGuess = None,fullBody=None, viewer =None):
+    raise NotImplemented("TODO")

--- a/scripts/mlp/centroidal/topt.py
+++ b/scripts/mlp/centroidal/topt.py
@@ -297,7 +297,9 @@ def addInitAndGoalShift(cs_in):
     return cs
     
 
-def generateCentroidalTrajectory(cs,cs_initGuess = None, viewer =None):
+def generateCentroidalTrajectory(cs,cs_initGuess = None,fullBody=None, viewer =None):
+    if cs_initGuess:
+        print "WARNING : in current implementation of timeopt.generateCentroidalTrajectory the initial guess is ignored. (TODO)"
     q_init = cs.contact_phases[0].reference_configurations[0].copy()
     num_phases = cs.size()
     ee_ids = [timeopt.EndeffectorID.RF, timeopt.EndeffectorID.LF,timeopt.EndeffectorID.RH,timeopt.EndeffectorID.LH]
@@ -344,4 +346,4 @@ def generateCentroidalTrajectory(cs,cs_initGuess = None, viewer =None):
     if cfg.TIME_SHIFT_COM > 0 :
         cs_result = addInitAndGoalShift(cs_result)
     
-    return cs_result, tp
+    return cs_result

--- a/scripts/mlp/centroidal/topt.py
+++ b/scripts/mlp/centroidal/topt.py
@@ -66,17 +66,7 @@ def isNewPhase(tp,k0,k1,cs_com,cs_initGuess,p_id):
         return isNewPhaseFromCS(cs_com,cs_initGuess,p_id)
     else : 
         return isNewPhaseFromContact(tp,k0,k1)
-        
-
-## helper method to deal with StateVectorState and other exposed c++ vectors : 
-# replace vec[i] with value if it already exist or append the value
-def appendOrReplace(vec,i,value):
-    assert len(vec) >= i , "There is an uninitialized gap in the vector."
-    if i < len(vec) :
-        vec[i] = value
-    else :
-        vec.append(value)
-        
+       
 def fillCSFromTimeopt(cs,cs_initGuess,tp):
     cs_com = ContactSequenceHumanoid(cs)
     
@@ -219,15 +209,8 @@ def extractAllEffectorsPhasesFromCS(cs,cs_initGuess,ee_ids):
             effectors_phases.update({ee:ee_phases})
     return effectors_phases,size
 
-def copyPhaseContacts(phase_in,phase_out):
-    phase_out.RF_patch = phase_in.RF_patch
-    phase_out.LF_patch = phase_in.LF_patch
-    phase_out.RH_patch = phase_in.RH_patch
-    phase_out.LH_patch = phase_in.LH_patch
-    
 # fill state trajectory and time trajectory with a linear trajectory connecting init_state to final_state
 # the trajectories vectors must be empty when calling this method ! 
-# Note : don't fill control_traj for now
 def generateLinearInterpTraj(phase,duration,t_total):
     com0 = phase.init_state[0:3]
     com1 = phase.final_state[0:3]

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -62,6 +62,7 @@ IK_dt = 0.001  # controler time step
 IK_PRINT_N = 500  # print state of the problem every IK_PRINT_N time steps (if verbose = True)
 CHECK_FINAL_MOTION = True
 IK_store_centroidal = True
+IK_store_zmp = True # need store_centroidal
 IK_store_effector = True
 IK_store_error = True
 IK_store_contact_forces = True

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -8,9 +8,9 @@ wholebody_method_available = ["load", "tsid", "croccodyl"]
 end_effector_method_available = ["smoothedFoot", "bezierPredef", "bezierConstrained", "limbRRT", "limbRRToptimized"]
 
 ## methods setting : choose which method will be used to solve each subproblem : 
-contact_generation_method = "load" 
+contact_generation_method = "rbprm" 
 centroidal_initGuess_method = "geometric" 
-centroidal_method = "load" 
+centroidal_method = "timeopt" 
 wholebody_method = "tsid" 
 end_effector_method = "limbRRToptimized" 
 

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -25,8 +25,8 @@ DISPLAY_FEET_TRAJ = True
 DISPLAY_WB_MOTION = False
 DT_DISPLAY = 0.05 # dt used to display the wb motion
 PLOT = True
-DISPLAY_PLOT = True
-SAVE_PLOT = True
+DISPLAY_PLOT = PLOT and True
+SAVE_PLOT = PLOT and True
 
 ###  Settings for generate_contact_sequence
 FORCE_STRAIGHT_LINE = False # DEBUG ONLY should be false
@@ -64,7 +64,6 @@ CHECK_FINAL_MOTION = True
 IK_store_centroidal = True
 IK_store_zmp = True # need store_centroidal
 IK_store_effector = True
-IK_store_error = True
 IK_store_contact_forces = True
 # import specific settings for the selected demo. This settings may override default ones.
 import importlib

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -19,6 +19,7 @@ PKG_PATH = os.environ['DEVEL_HPP_DIR']+"/src/multicontact-locomotion-planning"
 OUTPUT_DIR = PKG_PATH+"/res"
 CONTACT_SEQUENCE_PATH = OUTPUT_DIR + "/contact_sequences"
 TIME_OPT_CONFIG_PATH = PKG_PATH +'/timeOpt_configs'
+STATUS_FILENAME = "infos.log"
 SAVE_CS = True 
 SAVE_CS_COM = True
 EXPORT_GAZEBO = False
@@ -27,7 +28,7 @@ EXPORT_NPZ = True
 EXPORT_BLENDER = False
 openHRP_useZMPref = False
 EXPORT_PATH = OUTPUT_DIR+"/export"
-
+WRITE_STATUS = True
 ##DISPLAY settings : 
 DISPLAY_CS = False # display contact sequence from rbprm
 DISPLAY_CS_STONES = True # display stepping stones

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -46,8 +46,8 @@ TIME_SHIFT_COM = 0.0
 USE_WP_COST = True # use wp from the contact sequence in the cost function of timeopt
 
 ## Settings for end effector :
-USE_LIMB_RRT = False
-USE_CONSTRAINED_BEZIER = True
+USE_LIMB_RRT = True
+USE_CONSTRAINED_BEZIER = False
 USE_BEZIER_EE = True
 EFF_CHECK_COLLISION = True
 WB_ABORT_WHEN_INVALID = False

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -1,18 +1,31 @@
-## PATHS settings : 
 import numpy as np
 import os
+
+contact_generation_method_available = ["none","load", "rbprm"]
+centroidal_initGuess_method_available = ["none", "geometric", "croc", "timeopt", "quasistatic"]
+centroidal_method_available = ["load", "geometric", "croc", "timeopt", "quasistatic", "muscod"]
+wholebody_method_available = ["load", "tsid", "croccodyl"]
+end_effector_method_available = ["smoothedFoot", "bezierPredef", "bezierConstrained", "limbRRT", "limbRRToptimized"]
+
+## methods setting : choose which method will be used to solve each subproblem : 
+contact_generation_method = "load" 
+centroidal_initGuess_method = "geometric" 
+centroidal_method = "load" 
+wholebody_method = "tsid" 
+end_effector_method = "limbRRToptimized" 
+
+## PATHS settings : 
 PKG_PATH = os.environ['DEVEL_HPP_DIR']+"/src/multicontact-locomotion-planning"
 OUTPUT_DIR = PKG_PATH+"/res"
 CONTACT_SEQUENCE_PATH = OUTPUT_DIR + "/contact_sequences"
 TIME_OPT_CONFIG_PATH = PKG_PATH +'/timeOpt_configs'
-LOAD_CS = True
-LOAD_CS_COM = True
-SAVE_CS = not LOAD_CS and True 
-SAVE_CS_COM = not LOAD_CS_COM and True
+SAVE_CS = True 
+SAVE_CS_COM = True
 EXPORT_GAZEBO = False
 EXPORT_OPENHRP = False
 EXPORT_NPZ = True
-openHRP_useZMPref = True
+EXPORT_BLENDER = False
+openHRP_useZMPref = False
 EXPORT_PATH = OUTPUT_DIR+"/export"
 
 ##DISPLAY settings : 
@@ -34,30 +47,22 @@ FORCE_STRAIGHT_LINE = False # DEBUG ONLY should be false
 ### Settings for centroidal script :
 MU=0.5
 GRAVITY = np.matrix([0,0,-9.81]).T
-USE_GEOM_INIT_GUESS = True
-USE_CROC_INIT_GUESS = False
-assert USE_GEOM_INIT_GUESS != USE_CROC_INIT_GUESS , "You must choose exactly one initial guess"
 SOLVER_DT = 0.05 # hardcoded in timeOpt_configs files, must match this one ! 
 
 # hardcoded height change between the init (goal) position from planning and the one given to the centroidal solver
 COM_SHIFT_Z = 0.0
 TIME_SHIFT_COM = 0.0
-
 USE_WP_COST = True # use wp from the contact sequence in the cost function of timeopt
 
 ## Settings for end effector :
-USE_LIMB_RRT = True
-USE_CONSTRAINED_BEZIER = False
-USE_BEZIER_EE = True
 EFF_CHECK_COLLISION = True
-WB_ABORT_WHEN_INVALID = False
-WB_RETURN_INVALID = not WB_ABORT_WHEN_INVALID and True
+WB_ABORT_WHEN_INVALID = True # stop wb script when detecting a collision and return the VALID part (before the phase with collision
+WB_RETURN_INVALID = not WB_ABORT_WHEN_INVALID and False  # stop wb script when detecting a collision and return  the computed part of motion, incuding the last INVALID phase
 
 ##  Settings for whole body : 
 YAW_ROT_GAIN = 1.
-USE_CROC_COM = False
 WB_VERBOSE = 0 # 0,1 or 2
-WB_STOP_AT_EACH_PHASE = False
+WB_STOP_AT_EACH_PHASE = False # wait for user input between each phase
 IK_dt = 0.001  # controler time step
 IK_PRINT_N = 500  # print state of the problem every IK_PRINT_N time steps (if verbose = True)
 CHECK_FINAL_MOTION = True
@@ -65,6 +70,38 @@ IK_store_centroidal = True
 IK_store_zmp = True # need store_centroidal
 IK_store_effector = True
 IK_store_contact_forces = True
+
+
+# check if method_type choosen are coherent : 
+if not(contact_generation_method in contact_generation_method_available):
+    raise ValueError("contact generation method must be choosed from : "+str(contact_generation_method_available))
+if not(centroidal_initGuess_method in centroidal_initGuess_method_available):
+    raise ValueError("centroidal initGuess method must be choosed from : "+str(centroidal_initGuess_method_available))
+if not(centroidal_method in centroidal_method_available):
+    raise ValueError("centroidal method must be choosed from : "+str(centroidal_method_available))
+if not(wholebody_method in wholebody_method_available):
+    raise ValueError("wholebody method must be choosed from : "+str(wholebody_method_available))
+if not(end_effector_method in end_effector_method_available):
+    raise ValueError("end effector method must be choosed from : "+str(end_effector_method_available))
+if contact_generation_method == "none" and centroidal_method != "load" :
+    raise ValueError("Cannot skip contact_generation phase if centroidal trajectory is not loaded from file")
+if centroidal_method == "timeopt" and centroidal_initGuess_method != "geometric":
+    raise ValueError("In current implementation of timeopt, the initGuess must be geometric (FIXME)")
+if (centroidal_method == "croc" or centroidal_initGuess_method == "croc") and contact_generation_method != "rbprm":
+    raise ValueError("In current implementation of CROC, contact generation method should be RBPRM (FIXME)")
+
+# skip useless ethod when loading motion from file: 
+if contact_generation_method == "load":
+    SAVE_CS = False
+if centroidal_method == "load":
+    centroidal_initGuess_method = "none"
+    SAVE_CS_COM = False
+if wholebody_method == "load":
+    contact_generation_method = "none"
+    centroidal_initGuess_method = "none"
+    centroidal_method= "load"
+    EXPORT_NPZ = False
+
 # import specific settings for the selected demo. This settings may override default ones.
 import importlib
 import sys

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -124,8 +124,10 @@ else :
     # Import the module
     try :
         demo_cfg = importlib.import_module('mlp.demo_configs.'+DEMO_NAME)
-    except ImportError:
-        raise NameError("No demo config file with the given name in mlp.demo_config")
+    except ImportError, e:
+        print "Cannot load config file '"+DEMO_NAME+"' from mlp.demo_config, error : "
+        print e.message
+        raise NameError("Cannot load config file '"+DEMO_NAME+"' from mlp.demo_config")
     # Determine a list of names to copy to the current name space
     names = getattr(demo_cfg, '__all__', [n for n in dir(demo_cfg) if not n.startswith('_')])
     # Copy those names into the current name space

--- a/scripts/mlp/config.py
+++ b/scripts/mlp/config.py
@@ -87,8 +87,6 @@ if contact_generation_method == "none" and centroidal_method != "load" :
     raise ValueError("Cannot skip contact_generation phase if centroidal trajectory is not loaded from file")
 if centroidal_method == "timeopt" and centroidal_initGuess_method != "geometric":
     raise ValueError("In current implementation of timeopt, the initGuess must be geometric (FIXME)")
-if (centroidal_method == "croc" or centroidal_initGuess_method == "croc") and contact_generation_method != "rbprm":
-    raise ValueError("In current implementation of CROC, contact generation method should be RBPRM (FIXME)")
 
 # skip useless ethod when loading motion from file: 
 if contact_generation_method == "load":

--- a/scripts/mlp/contact_sequence/__init__.py
+++ b/scripts/mlp/contact_sequence/__init__.py
@@ -1,0 +1,16 @@
+import mlp.config as cfg
+
+# contact_generation_method_available = ["none","load", "rbprm"]
+
+method = cfg.contact_generation_method
+
+if method == "none":
+    from mlp.viewer.display_tools import initScene
+    def generateContactSequence():
+        return None,initScene(cfg.Robot,cfg.ENV_NAME)
+elif method == "load":
+    from .fromCSfile import generateContactSequence
+elif method == "rbprm":
+    from .rbprm import generateContactSequence
+else :
+    raise ValueError("method type "+str(method)+" doesn't exist for contact generation")

--- a/scripts/mlp/contact_sequence/fromCSfile.py
+++ b/scripts/mlp/contact_sequence/fromCSfile.py
@@ -3,7 +3,7 @@ import mlp.config as cfg
 import mlp.viewer.display_tools as display_tools
 
 def generateContactSequence():
-    v,fb = display_tools.initScene(cfg.Robot,cfg.ENV_NAME)
+    fb,v = display_tools.initScene(cfg.Robot,cfg.ENV_NAME)
     cs = ContactSequenceHumanoid(0)
     filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME   
     print "Import contact sequence binary file : ",filename    

--- a/scripts/mlp/contact_sequence/fromCSfile.py
+++ b/scripts/mlp/contact_sequence/fromCSfile.py
@@ -1,0 +1,12 @@
+from multicontact_api import ContactSequenceHumanoid
+import mlp.config as cfg
+import mlp.viewer.display_tools as display_tools
+
+def generateContactSequence():
+    v,fb = display_tools.initScene(cfg.Robot,cfg.ENV_NAME)
+    cs = ContactSequenceHumanoid(0)
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME   
+    print "Import contact sequence binary file : ",filename    
+    cs.loadFromBinary(filename) 
+    display_tools.displayWBconfig(v,cs.contact_phases[0].reference_configurations[0])
+    return cs,fb,v

--- a/scripts/mlp/contact_sequence/fromCSfile.py
+++ b/scripts/mlp/contact_sequence/fromCSfile.py
@@ -5,7 +5,7 @@ import mlp.viewer.display_tools as display_tools
 def generateContactSequence():
     fb,v = display_tools.initScene(cfg.Robot,cfg.ENV_NAME)
     cs = ContactSequenceHumanoid(0)
-    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME   
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+".cs"   
     print "Import contact sequence binary file : ",filename    
     cs.loadFromBinary(filename) 
     display_tools.displayWBconfig(v,cs.contact_phases[0].reference_configurations[0])

--- a/scripts/mlp/contact_sequence/rbprm.py
+++ b/scripts/mlp/contact_sequence/rbprm.py
@@ -36,8 +36,6 @@ def contactSequenceFromRBPRMConfigs(fb,configs,beginId,endId):
     # config only contains the double support stance
     n_steps = n_double_support*2 -1 
     # Notice : what we call double support / simple support are in fact the state with all the contacts and the state without the next moving contact
-    extraDOF = int(fb.client.robot.getDimensionExtraConfigSpace())
-    configSize = fb.client.robot.getConfigSize() - extraDOF
     cs = ContactSequenceHumanoid(n_steps)
     unusedPatch = cs.contact_phases[0].LF_patch.copy()
     unusedPatch.placement = SE3.Identity()
@@ -156,7 +154,7 @@ def contactSequenceFromRBPRMConfigs(fb,configs,beginId,endId):
         #phase_d.time_trajectory.append((fb.getDurationForState(stateId))*cfg.DURATION_n_CONTACTS/cfg.SPEED)
         phase_d.init_state=init_state
         phase_d.final_state=final_state
-        phase_d.reference_configurations.append(np.matrix((configs[config_id][:configSize])).T)        
+        phase_d.reference_configurations.append(np.matrix((configs[config_id])).T)        
         #print "done for double support"
         
         if stateId < endId :
@@ -183,7 +181,7 @@ def contactSequenceFromRBPRMConfigs(fb,configs,beginId,endId):
                     phase_s.RH_patch.active = False
             # retrieve the COM position for init and final state 
              
-            phase_s.reference_configurations.append(np.matrix((configs[config_id][:configSize])).T)
+            phase_s.reference_configurations.append(np.matrix((configs[config_id])).T)
             init_state = phase_d.init_state.copy()
             final_state = phase_d.final_state.copy()
             fb.setCurrentConfig(configs[config_id+1])

--- a/scripts/mlp/contact_sequence/rbprm.py
+++ b/scripts/mlp/contact_sequence/rbprm.py
@@ -149,7 +149,7 @@ def contactSequenceFromRBPRMConfigs(fb,configs,beginId,endId):
                     phase_d.RH_patch.placement = MRH
                     
         # retrieve the COM position for init and final state (equal for double support phases)
-        init_state = phase_d.init_state.copy()
+        init_state = np.matrix(np.zeros(9)).T
         init_state[0:3] = np.matrix(fb.getCenterOfMass()).transpose()
         init_state[3:6] = np.matrix(configs[config_id][-6:-3]).transpose()
         final_state = init_state.copy()

--- a/scripts/mlp/contact_sequence/rbprm.py
+++ b/scripts/mlp/contact_sequence/rbprm.py
@@ -7,9 +7,26 @@ import multicontact_api
 from multicontact_api import WrenchCone,SOC6,ContactPatch, ContactPhaseHumanoid, ContactSequenceHumanoid
 global i_sphere 
 from mlp.utils.util import quatFromConfig
+import importlib
 
+def runRBPRMScript():
+    #the following script must produce a sequence of configurations in contact (configs) 
+    # with exactly one contact change between each configurations
+    # It must also initialise a FullBody object name fullBody and optionnaly a Viewer object named V    
+    scriptName = 'scenarios.'+cfg.SCRIPT_PATH+'.'+cfg.DEMO_NAME
+    print "Run RBPRM script : ",scriptName
+    cp = importlib.import_module(scriptName)
+    if hasattr(cp,'beginId'):
+        beginId = cp.beginId
+    else :
+        beginId = 0
+    if hasattr(cp,'endId'):
+        endId = cp.endId
+    else :    
+        endId = len(cp.configs) - 1    
+    return cp.fullBody,cp.v,cp.configs,beginId,endId
 
-def generateContactSequence(fb,configs,beginId,endId):
+def contactSequenceFromRBPRMConfigs(fb,configs,beginId,endId):
     print "generate contact sequence from planning : "
     global i_sphere
     i_sphere = 0
@@ -176,78 +193,7 @@ def generateContactSequence(fb,configs,beginId,endId):
             phase_s.init_state=init_state.copy()
             phase_s.final_state=final_state.copy()
             #print "done for single support"      
-    
-    """    
-    # add the final double support stance : 
-    phase_d = cs.contact_phases[n_steps-1]
-    fb.setCurrentConfig(configs[n_double_support - 1])
-    # compute MRF and MLF : the position of the contacts
-    q_rl = fb.getJointPosition(fb.rfoot)
-    q_ll = fb.getJointPosition(fb.lfoot)
-    q_rh = fb.getJointPosition(fb.rhand)
-    q_lh = fb.getJointPosition(fb.lhand)
 
-    # feets
-    MRF = SE3.Identity()
-    MLF = SE3.Identity()
-    MRF.translation = np.matrix(q_rl[0:3]).T
-    MLF.translation = np.matrix(q_ll[0:3]).T
-    if not cfg.FORCE_STRAIGHT_LINE :  
-        rot_rl = quatFromConfig(q_rl)
-        rot_ll = quatFromConfig(q_ll)
-        MRF.rotation = rot_rl.matrix()
-        MLF.rotation = rot_ll.matrix()
-    # apply the transform ankle -> center of contact
-    MRF *= fb.MRsole_offset
-    MLF *= fb.MLsole_offset
-
-    # hands
-    MRH = SE3()
-    MLH = SE3()
-    MRH.translation = np.matrix(q_rh[0:3]).T
-    MLH.translation = np.matrix(q_lh[0:3]).T
-    rot_rh = quatFromConfig(q_rh)
-    rot_lh = quatFromConfig(q_lh)
-    MRH.rotation = rot_rh.matrix()
-    MLH.rotation = rot_lh.matrix()   
-    
-    MRH *= fb.MRhand_offset
-    MLH *= fb.MLhand_offset    
-    
-    # we need to copy the unchanged patch from the last simple support phase (and not create a new one with the same placement
-    phase_d.RF_patch = phase_s.RF_patch
-    phase_d.RF_patch.active = fb.isLimbInContact(fb.rLegId,endId)
-    phase_d.LF_patch = phase_s.LF_patch
-    phase_d.LF_patch.active = fb.isLimbInContact(fb.lLegId,endId)
-    phase_d.RH_patch = phase_s.RH_patch
-    phase_d.RH_patch.active = fb.isLimbInContact(fb.rArmId,endId)
-    phase_d.LH_patch = phase_s.LH_patch
-    phase_d.LH_patch.active = fb.isLimbInContact(fb.lArmId,endId)
-    
-    # now we change the contacts that have moved : 
-    variations = fb.getContactsVariations(endId-1,endId)
-    #assert len(variations)==1, "Several changes of contacts in adjacent states, not implemented yet !"
-    for var in variations:     
-        # FIXME : for loop in variation ? how ?
-        if var == fb.lLegId:
-            phase_d.LF_patch.placement = MLF
-        if var == fb.rLegId:
-            phase_d.RF_patch.placement = MRF
-        if var == fb.lArmId:
-            phase_d.LH_patch.placement = MLH
-        if var == fb.rArmId:
-            phase_d.RH_patch.placement = MRH
-    # retrieve the COM position for init and final state (equal for double support phases)    
-    phase_d.reference_configurations.append(np.matrix((configs[-1][:configSize])).T)
-    init_state = phase_d.init_state
-    init_state[0:3] = np.matrix(fb.getCenterOfMass()).transpose()
-    init_state[3:9] = np.matrix(configs[-1][-6:]).transpose()
-    final_state = init_state.copy()
-    #phase_d.time_trajectory.append(0.)
-    phase_d.init_state=init_state
-    phase_d.final_state=final_state   
-    #print "done for last state"
-    """
     # assign contact models : 
     # only used by muscod ?? But we need to fill it otherwise the serialization fail
     for k,phase in enumerate(cs.contact_phases):
@@ -273,3 +219,8 @@ def generateContactSequence(fb,configs,beginId,endId):
         RH_patch.contactModelPlacement = SE3.Identity()    
         
     return cs
+
+def generateContactSequence():
+    fb,viewer,configs,beginId,endId = runRBPRMScript()
+    cs = contactSequenceFromRBPRMConfigs(fb,configs,beginId,endId)
+    return cs,fb,viewer

--- a/scripts/mlp/demo_configs/anymal_flatGround.py
+++ b/scripts/mlp/demo_configs/anymal_flatGround.py
@@ -1,6 +1,8 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_anymal.yaml"
 from common_anymal import *
 SCRIPT_PATH = "sandbox.ANYmal"
+ENV_NAME = "multicontact/ground"
+
 
 DURATION_INIT = 1.5 # Time to init the motion
 DURATION_FINAL = 1.5 # Time to stop the robot

--- a/scripts/mlp/demo_configs/anymal_slalom_debris.py
+++ b/scripts/mlp/demo_configs/anymal_slalom_debris.py
@@ -1,6 +1,7 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_anymal.yaml"
 from common_anymal import *
 SCRIPT_PATH = "sandbox.ANYmal"
+ENV_NAME = "multicontact/slalom_debris"
 
 DURATION_INIT = 1.5 # Time to init the motion
 DURATION_FINAL = 1.5 # Time to stop the robot

--- a/scripts/mlp/demo_configs/common_anymal.py
+++ b/scripts/mlp/demo_configs/common_anymal.py
@@ -4,17 +4,31 @@ MASS = 30.47 # cannot retrieve it from urdf because the file is not parsed here 
 ## weight and gains used by TSID
 
 fMin = 1.0                      # minimum normal force
-fMax = 1000.0                  # maximum normal force
+fMax = 200.                  # maximum normal force
 w_com = 1.0                     # weight of center of mass task
-w_posture = 0.75                 # weight of joint posture task
+w_posture = 1e-3                 # weight of joint posture task
+w_am = 1.
 w_rootOrientation = 1.0         # weight of the root's orientation task
-w_forceRef = 1e-3               # weight of force regularization task
+w_forceRef = 1e-5               # weight of force regularization task
 w_eff = 1.0                     # weight of the effector motion task
-kp_contact = 30.0               # proportional gain of contact constraint
-kp_com = 3000.0                 # proportional gain of center of mass task
+kp_contact = 10.0               # proportional gain of contact constraint
+kp_com = 10.0                # proportional gain of center of mass task
 kp_posture = 10.0               # proportional gain of joint posture task
-kp_rootOrientation = 500.0      # proportional gain of the root's orientation task
-kp_Eff = 3000.0                 # proportional gain ofthe effectors motion task
+kp_am = 10.
+kp_rootOrientation = 50.0     # proportional gain of the root's orientation task
+kp_Eff = 100.0                 # proportional gain ofthe effectors motion task
+level_eff = 0
+level_com = 0
+level_posture = 1
+level_rootOrientation = 1
+level_am = 1
+
+IK_eff_size = Robot.dict_size.copy()
+
+## Settings for end effectors : 
+EFF_T_PREDEF = 0.1
+EFF_T_DELAY = 0.05
+p_max = 0.1
 
 import numpy as np
 gain_vector = np.matrix(np.ones(24)).T

--- a/scripts/mlp/demo_configs/common_talos.py
+++ b/scripts/mlp/demo_configs/common_talos.py
@@ -1,5 +1,16 @@
 from hpp.corbaserver.rbprm.talos import Robot
 MASS = 90.27
+
+## predef duration of contact phases : 
+DURATION_INIT = 1.5 # Time to init the motion
+DURATION_FINAL = 1 # Time to stop the robot
+DURATION_FINAL_SS = 1.
+DURATION_SS =1.2
+DURATION_DS = 0.3
+DURATION_TS = 0.4
+DURATION_CONNECT_GOAL = 1.5
+
+
 ## weight and gains used by TSID
 fMin = 1.0                      # minimum normal force
 fMax = 1000.                   # maximum normal force
@@ -34,8 +45,8 @@ gain_vector = np.matrix(
     [ 10. ,  5.  , 5. , 1. ,  1. ,  10., # lleg  #low gain on axis along y and knee
     10. ,  5.  , 5. , 1. ,  1. ,  10., #rleg
     500. , 500.  , #chest
-    50.,   10.  , 10.,  10.,    10. ,  10. , 10. ,  10. , #larm
-    50.,   10.  , 10., 10.,    10. ,  10. ,  10. ,  10. , #rarm
+    50.,   100.  , 10.,  10.,    10. ,  10. , 10. ,  10. , #larm
+    50.,   100.  , 10., 10.,    10. ,  10. ,  10. ,  10. , #rarm
    100.,  100.] #head
     ).T   # gain vector for postural task :
 

--- a/scripts/mlp/demo_configs/darpa_hyq.py
+++ b/scripts/mlp/demo_configs/darpa_hyq.py
@@ -1,6 +1,8 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_hyq.yaml"
 from common_hyq import *
 SCRIPT_PATH = "demos"
+ENV_NAME = "multicontact/darpa"
+
 DURATION_INIT = 1.5 # Time to init the motion
 DURATION_FINAL = 1.5 # Time to stop the robot
 DURATION_FINAL_SS = 1.

--- a/scripts/mlp/demo_configs/hrp2_flatGround.py
+++ b/scripts/mlp/demo_configs/hrp2_flatGround.py
@@ -1,6 +1,7 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_hrp2.yaml"
 from common_hrp2 import *
 SCRIPT_PATH = "demos"
+ENV_NAME = "multicontact/ground"
 
 DURATION_INIT = 1. # Time to init the motion
 DURATION_FINAL = 1.5 # Time to stop the robot

--- a/scripts/mlp/demo_configs/hrp2_pushRecovery.py
+++ b/scripts/mlp/demo_configs/hrp2_pushRecovery.py
@@ -3,6 +3,7 @@ TIMEOPT_CONFIG_FILE = "cfg_softConstraints_hrp2_eff85.yaml"
 
 from common_hrp2 import *
 SCRIPT_PATH = "sandbox"
+ENV_NAME = "multicontact/ground"
 
 DURATION_INIT = 1. # Time to init the motion
 DURATION_FINAL = 1.5 # Time to stop the robot

--- a/scripts/mlp/demo_configs/hyq_slalom_debris.py
+++ b/scripts/mlp/demo_configs/hyq_slalom_debris.py
@@ -1,6 +1,7 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_hyq.yaml"
 from common_hyq import *
 SCRIPT_PATH = "demos"
+ENV_NAME = "multicontact/slalom_debris"
 
 DURATION_INIT = 1.5 # Time to init the motion
 DURATION_FINAL = 1.5 # Time to stop the robot

--- a/scripts/mlp/demo_configs/talos_circle.py
+++ b/scripts/mlp/demo_configs/talos_circle.py
@@ -1,0 +1,11 @@
+TIMEOPT_CONFIG_FILE = "cfg_softConstraints_talos.yaml"
+from common_talos import *
+SCRIPT_PATH = "memmo"
+ENV_NAME = "multicontact/ground"
+
+kp_am = 1.
+w_am = 0.5
+
+EFF_T_PREDEF = 0.2
+EFF_T_DELAY = 0.05
+p_max = 0.07

--- a/scripts/mlp/demo_configs/talos_flatGround.py
+++ b/scripts/mlp/demo_configs/talos_flatGround.py
@@ -1,6 +1,7 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_talos.yaml"
 from common_talos import *
 SCRIPT_PATH = "demos"
+ENV_NAME = "multicontact/ground"
 
 DURATION_INIT = 1.5 # Time to init the motion
 DURATION_FINAL = 1.5 # Time to stop the robot

--- a/scripts/mlp/demo_configs/talos_flatGround.py
+++ b/scripts/mlp/demo_configs/talos_flatGround.py
@@ -4,9 +4,9 @@ SCRIPT_PATH = "demos"
 ENV_NAME = "multicontact/ground"
 
 DURATION_INIT = 1.5 # Time to init the motion
-DURATION_FINAL = 1.5 # Time to stop the robot
+DURATION_FINAL = 1 # Time to stop the robot
 DURATION_FINAL_SS = 1.
 DURATION_SS =1.4
 DURATION_DS = 0.3
 DURATION_TS = 0.4
-
+DURATION_CONNECT_GOAL = 1.

--- a/scripts/mlp/demo_configs/talos_pushRecovery.py
+++ b/scripts/mlp/demo_configs/talos_pushRecovery.py
@@ -1,6 +1,7 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_talos_dt001.yaml"
 from common_talos import *
 SCRIPT_PATH = "sandbox"
+ENV_NAME = "multicontact/ground"
 
 DURATION_INIT = 0.5 # Time to init the motion
 DURATION_FINAL = 2.0 # Time to stop the robot

--- a/scripts/mlp/end_effector/__init__.py
+++ b/scripts/mlp/end_effector/__init__.py
@@ -9,13 +9,19 @@ if method == "smoothedFoot":
         if numTry > 0 :
             raise ValueError("SmoothedFootTrajectory will always produce the same trajectory, cannot be called with numTry > 0 ")        
         return SmoothedFootTrajectory(time_interval, [placement_init,placement_end]) 
+    def effectorCanRetry():
+        return False
 elif method == "bezierPredef":
     from .bezier_predef import generateSmoothBezierTraj as generateEndEffectorTraj
+    from .bezier_predef import effectorCanRetry
 elif method == "bezierConstrained":
     from .bezier_constrained import generateConstrainedBezierTraj as generateEndEffectorTraj
+    from .bezier_constrained import effectorCanRetry    
 elif method == "limbRRT":
     from .limb_rrt import generateLimbRRTTraj as generateEndEffectorTraj
+    from .limb_rrt import effectorCanRetry    
 elif method == "limbRRToptimized":
     from .limb_rrt import generateLimbRRTOptimizedTraj as generateEndEffectorTraj
+    from .limb_rrt import effectorCanRetry    
 else : 
     raise ValueError("method type "+str(method)+" doesn't exist for end-effector trajectory generation")

--- a/scripts/mlp/end_effector/__init__.py
+++ b/scripts/mlp/end_effector/__init__.py
@@ -1,0 +1,21 @@
+import mlp.config as cfg 
+
+#end_effector_method = ["smoothedFoot", "bezierPredef", "bezierConstrained", "limbRRT", "limbRRToptimized"]
+method = cfg.end_effector_method
+# prototype must be : in : (time_interval,placement_init,placement_end,numTry,q_t=None,phase_previous=None,phase=None,phase_next=None,fullBody=None,eeName=None,viewer=None) out : Trajectorie
+if method == "smoothedFoot":
+    from mlp.utils.trajectories import SmoothedFootTrajectory
+    def generateEndEffectorTraj(time_interval,placement_init,placement_end,numTry=None,q_t=None,phase_previous=None,phase=None,phase_next=None,fullBody=None,eeName=None,viewer=None):
+        if numTry > 0 :
+            raise ValueError("SmoothedFootTrajectory will always produce the same trajectory, cannot be called with numTry > 0 ")        
+        return SmoothedFootTrajectory(time_interval, [placement_init,placement_end]) 
+elif method == "bezierPredef":
+    from .bezier_predef import generateSmoothBezierTraj as generateEndEffectorTraj
+elif method == "bezierConstrained":
+    from .bezier_constrained import generateConstrainedBezierTraj as generateEndEffectorTraj
+elif method == "limbRRT":
+    from .limb_rrt import generateLimbRRTTraj as generateEndEffectorTraj
+elif method == "limbRRToptimized":
+    from .limb_rrt import generateLimbRRTOptimizedTraj as generateEndEffectorTraj
+else : 
+    raise ValueError("method type "+str(method)+" doesn't exist for end-effector trajectory generation")

--- a/scripts/mlp/end_effector/bezier_constrained.py
+++ b/scripts/mlp/end_effector/bezier_constrained.py
@@ -64,6 +64,8 @@ triangles_ids = [
 		[3, 2, 6,],
 		[6, 7, 3]]
 
+def effectorCanRetry():
+    return True
 
 #min (1/2)x' P x + q' x  
 #subject to  G x <= h

--- a/scripts/mlp/end_effector/bezier_constrained.py
+++ b/scripts/mlp/end_effector/bezier_constrained.py
@@ -643,7 +643,7 @@ def computeProblemConstraints(pData,fullBody,pathId,t,eeName,viewer):
     return pDef
 
 
-def generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_init,q_end,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,viewer):
+def generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_t,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,viewer):
     t_total = time_interval[1]-time_interval[0]
     predef_curves = predefTraj.curves
     bezier_takeoff = predef_curves.curves[predef_curves.idFirstNonZero()]
@@ -661,7 +661,8 @@ def generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_i
     if VERBOSE : 
         print "t begin : ",t_begin
         print "t end   : ",t_end
-
+    q_init = q_t[:,int(t_begin/cfg.IK_dt)] # after the predef takeoff
+    q_end = q_t[:,int(t_end/cfg.IK_dt)]
     # compute limb-rrt path : 
     pathId = limb_rrt.generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody,phaseId)
             

--- a/scripts/mlp/end_effector/bezier_constrained.py
+++ b/scripts/mlp/end_effector/bezier_constrained.py
@@ -643,7 +643,7 @@ def computeProblemConstraints(pData,fullBody,pathId,t,eeName,viewer):
     return pDef
 
 
-def generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_t,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,viewer):
+def generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_init,q_end,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,viewer):
     t_total = time_interval[1]-time_interval[0]
     predef_curves = predefTraj.curves
     bezier_takeoff = predef_curves.curves[predef_curves.idFirstNonZero()]
@@ -661,8 +661,6 @@ def generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_t
     if VERBOSE : 
         print "t begin : ",t_begin
         print "t end   : ",t_end
-    q_init = q_t[int(t_begin/cfg.IK_dt)]
-    q_end = q_t[int(t_end/cfg.IK_dt)]
 
     # compute limb-rrt path : 
     pathId = limb_rrt.generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody,phaseId)
@@ -699,7 +697,7 @@ def generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_t
     while not solved and numVars <=5:
         pData.constraints_.flag_ = flagData | flags[numVars-1]
         ineqEff = bezier_com.computeEndEffectorConstraints(pData,t_middle)
-        Hg = bezier_com.computeEndEffectorCost(pData,t_middle)
+        Hg = bezier_com.computeEndEffectorVelocityCost(pData,t_middle)
         res = bezier_com.computeEndEffector(pData,t_middle) #only used for comparison/debug ?
         bezier_unconstrained = res.c_of_t  
         pDef.degree = bezier_unconstrained.degree

--- a/scripts/mlp/end_effector/bezier_predef.py
+++ b/scripts/mlp/end_effector/bezier_predef.py
@@ -3,7 +3,7 @@ import time
 import os
 from mlp.utils.polyBezier import *
 import pinocchio as pin
-from pinocchio import SE3
+from pinocchio import SE3,Quaternion
 from pinocchio.utils import *
 import numpy.linalg
 from multicontact_api import WrenchCone,SOC6,ContactSequenceHumanoid

--- a/scripts/mlp/end_effector/bezier_predef.py
+++ b/scripts/mlp/end_effector/bezier_predef.py
@@ -96,7 +96,7 @@ def generatePredefLandingTakeoff(time_interval,placement_init,placement_end):
     bezier_takeoff = buildPredefinedInitTraj(placement_init,t_total)
     bezier_landing = buildPredefinedFinalTraj(placement_end,t_total)
     t_middle =  (t_total - (2.*cfg.EFF_T_PREDEF))
-    
+    assert t_middle >= 0.1 and "Duration of swing phase too short for effector motion. Change the values of predef motion for effector or the duration of the contact phase. "
     curves = []
     # create polybezier with concatenation of the 3 (or 5) curves :    
     # create constant curve at the beginning and end for the delay : 

--- a/scripts/mlp/end_effector/bezier_predef.py
+++ b/scripts/mlp/end_effector/bezier_predef.py
@@ -16,6 +16,10 @@ from mlp.utils import trajectories
 from mlp.utils.util import stdVecToMatrix
 import math
 
+def effectorCanRetry():
+    return False
+
+
 class Empty:
     None
     

--- a/scripts/mlp/end_effector/bezier_predef.py
+++ b/scripts/mlp/end_effector/bezier_predef.py
@@ -14,7 +14,7 @@ from hpp_spline import bezier
 import hpp_bezier_com_traj as bezier_com
 from mlp.utils import trajectories
 from mlp.utils.util import stdVecToMatrix
-
+import math
 
 class Empty:
     None
@@ -47,7 +47,7 @@ def buildPredefinedInitTraj(placement,t_total):
     #ddc1 = a_off * normal
     #create wp : 
     n = 4.
-    wps = np.matrix(np.zeros((3,int(n+1))))
+    wps = np.matrix(np.zeros(([3,int(n+1)])))
     T = cfg.EFF_T_PREDEF
     # constrained init pos and final pos. Init vel, acc and jerk = 0
     wps[:,0] = (c0); # c0
@@ -69,7 +69,7 @@ def buildPredefinedFinalTraj(placement,t_total):
     #ddc0 = a_off * normal
     #create wp : 
     n = 4.
-    wps = np.matrix(np.zeros((3,int(n+1))))
+    wps = np.matrix(np.zeros(([3,int(n+1)])))
     T = cfg.EFF_T_PREDEF
     # constrained init pos and final pos. final vel, acc and jerk = 0
     wps[:,0] = (c0); #c0
@@ -79,7 +79,9 @@ def buildPredefinedFinalTraj(placement,t_total):
     wps[:,4] = (c1); #c1
     return bezier(wps,T)
 
-def generateBezierTraj(placement_init,placement_end,time_interval):
+
+
+def generatePredefLandingTakeoff(time_interval,placement_init,placement_end):
     t_total = time_interval[1]-time_interval[0] - 2*cfg.EFF_T_DELAY
     #print "Generate Bezier Traj :"
     #print "placement Init = ",placement_init
@@ -89,6 +91,30 @@ def generateBezierTraj(placement_init,placement_end,time_interval):
     # generate a bezier curve for the middle part of the motion : 
     bezier_takeoff = buildPredefinedInitTraj(placement_init,t_total)
     bezier_landing = buildPredefinedFinalTraj(placement_end,t_total)
+    t_middle =  (t_total - (2.*cfg.EFF_T_PREDEF))
+    
+    curves = []
+    # create polybezier with concatenation of the 3 (or 5) curves :    
+    # create constant curve at the beginning and end for the delay : 
+    if cfg.EFF_T_DELAY > 0 :
+        bezier_init_zero=bezier(bezier_takeoff(0),cfg.EFF_T_DELAY)
+        curves.append(bezier_init_zero)
+    curves.append(bezier_takeoff)
+    curves.append(bezier(np.matrix(np.zeros(3)).T,t_middle)) # placeholder only
+    curves.append(bezier_landing)
+    if cfg.EFF_T_DELAY > 0 :
+        curves.append(bezier(bezier_landing(bezier_landing.max()),cfg.EFF_T_DELAY))    
+    pBezier = PolyBezier(curves) 
+    return pBezier
+    
+def generateSmoothBezierTraj(time_interval,placement_init,placement_end,numTry=None,q_t=None,phase_previous=None,phase=None,phase_next=None,fullBody=None,eeName=None,viewer=None):
+    if numTry > 0 :
+        raise ValueError("generateSmoothBezierTraj will always produce the same trajectory, cannot be called with numTry > 0 ")
+    predef_curves = generatePredefLandingTakeoff(time_interval,placement_init,placement_end)
+    bezier_takeoff = predef_curves.curves[predef_curves.idFirstNonZero()]
+    bezier_landing = predef_curves.curves[predef_curves.idLastNonZero()]
+    id_middle = int(math.floor(len(predef_curves.curves)/2.))    
+    # update mid curve to minimize velocity along the curve:
     # set problem data for mid curve : 
     pData = bezier_com.ProblemData() 
     pData.c0_ = bezier_takeoff(bezier_takeoff.max())
@@ -100,22 +126,13 @@ def generateBezierTraj(placement_init,placement_end,time_interval):
     pData.ddc1_ = bezier_landing.derivate(0,2)
     pData.j1_ = bezier_landing.derivate(0,3)    
     pData.constraints_.flag_ = bezier_com.ConstraintFlag.INIT_POS | bezier_com.ConstraintFlag.INIT_VEL | bezier_com.ConstraintFlag.INIT_ACC | bezier_com.ConstraintFlag.END_ACC | bezier_com.ConstraintFlag.END_VEL | bezier_com.ConstraintFlag.END_POS | bezier_com.ConstraintFlag.INIT_JERK | bezier_com.ConstraintFlag.END_JERK
-    t_middle =  (t_total - (2.*cfg.EFF_T_PREDEF))
+    t_middle =  predef_curves.curves[id_middle].max()
     res = bezier_com.computeEndEffector(pData,t_middle)
     bezier_middle = res.c_of_t
-    curves = []
-    # create polybezier with concatenation of the 3 (or 5) curves :    
-    # create constant curve at the beginning and end for the delay : 
-    if cfg.EFF_T_DELAY > 0 :
-        bezier_init_zero=bezier(bezier_takeoff(0),cfg.EFF_T_DELAY)
-        curves.append(bezier_init_zero)
-    curves.append(bezier_takeoff)
-    curves.append(bezier_middle)
-    curves.append(bezier_landing)
-    if cfg.EFF_T_DELAY > 0 :
-        curves.append(bezier(bezier_landing(bezier_landing.max()),cfg.EFF_T_DELAY))    
-    pBezier = PolyBezier(curves)
     
+    curves = predef_curves.curves[::]
+    curves[id_middle] = bezier_middle
+    pBezier = PolyBezier(curves)
     ref_traj = trajectories.BezierTrajectory(pBezier,placement_init,placement_end,time_interval)    
     return ref_traj
 

--- a/scripts/mlp/end_effector/limb_rrt.py
+++ b/scripts/mlp/end_effector/limb_rrt.py
@@ -8,7 +8,7 @@ import numpy.linalg
 from multicontact_api import WrenchCone,SOC6,ContactSequenceHumanoid
 import numpy as np
 import math
-from mlp.utils.util import stdVecToMatrix
+from mlp.utils.util import stdVecToMatrix, createStateFromPhase,effectorPositionFromHPPPath
 import eigenpy
 import hpp_bezier_com_traj as bezier_com
 from hpp_spline import bezier
@@ -55,19 +55,6 @@ def quadprog_solve_qp(P, q, G=None, h=None, C=None, d=None):
 
 
 
-def createStateFromPhase(fullBody,q,phase):
-    contacts = []
-    if phase.RF_patch.active:
-        contacts += [cfg.Robot.rLegId]
-    if phase.LF_patch.active:
-        contacts += [cfg.Robot.lLegId]
-    if phase.RH_patch.active:
-        contacts += [cfg.Robot.rArmId]
-    if phase.LH_patch.active:
-        contacts += [cfg.Robot.lArmId]
-    return fullBody.createState(q,contacts)
-
-
 def generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody) :
     assert fullBody and "Cannot use limb-rrt method as fullBody object is not defined."
     extraDof = int(fullBody.client.robot.getDimensionExtraConfigSpace())
@@ -75,8 +62,8 @@ def generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody) :
     q_end = q_end.T.tolist()[0] + [0]*extraDof
 
     # create nex states in fullBody corresponding to given configuration and set of contacts 
-    s0 = createStateFromPhase(fullBody,q_init,phase_previous)
-    s1 = createStateFromPhase(fullBody,q_end,phase_next)
+    s0 = createStateFromPhase(fullBody,phase_previous,q_init)
+    s1 = createStateFromPhase(fullBody,phase_next,q_end)
     if VERBOSE > 1: 
         print "New state added, q_init = ",q_init
         print "New state added, q_end = ",q_end

--- a/scripts/mlp/end_effector/limb_rrt.py
+++ b/scripts/mlp/end_effector/limb_rrt.py
@@ -164,7 +164,7 @@ def generateLimbRRTOptimizedTraj(time_interval,placement_init,placement_end,numT
     if numTry == 0 :
         return generateSmoothBezierTraj(time_interval,placement_init,placement_end)
     else :
-        if not q_t or not phase_previous or not phase or not phase_next or not fullBody or not eeName :
+        if q_t is None or phase_previous is None or phase is None or phase_next is None or not fullBody or not eeName :
             raise ValueError("Cannot compute LimbRRTOptimizedTraj for try >= 1 without optionnal arguments")
         
     predef_curves = generatePredefLandingTakeoff(time_interval,placement_init,placement_end)

--- a/scripts/mlp/end_effector/limb_rrt.py
+++ b/scripts/mlp/end_effector/limb_rrt.py
@@ -30,7 +30,8 @@ recompute_rrt_at_tries=[1,4,7,10, 16,23,23+len(weights_vars),23+2*len(weights_va
 # store the last limbRRT path ID computed        
 current_limbRRT_id = None
 
-
+def effectorCanRetry():
+    return True
 
 #min (1/2)x' P x + q' x  
 #subject to  G x <= h

--- a/scripts/mlp/end_effector/limb_rrt.py
+++ b/scripts/mlp/end_effector/limb_rrt.py
@@ -9,9 +9,50 @@ from multicontact_api import WrenchCone,SOC6,ContactSequenceHumanoid
 import numpy as np
 import math
 from mlp.utils.util import stdVecToMatrix
-VERBOSE = True
+import eigenpy
+import hpp_bezier_com_traj as bezier_com
+from hpp_spline import bezier
+from mlp.utils.polyBezier import PolyBezier
+import quadprog
+eigenpy.switchToNumpyArray()
+from mlp.utils import trajectories
+
+
+VERBOSE = 2
 DISPLAY_RRT_PATH = True
 DISPLAY_JOINT_LEVEL = True
+# order to try weight values and number of variables : 
+weights_vars = [[0.5,bezier_com.ConstraintFlag.ONE_FREE_VAR,1],[0.75,bezier_com.ConstraintFlag.ONE_FREE_VAR,1],[0.85,bezier_com.ConstraintFlag.ONE_FREE_VAR,1],[0.90,bezier_com.ConstraintFlag.ONE_FREE_VAR,1],[0.95,bezier_com.ConstraintFlag.ONE_FREE_VAR,1],[1.,bezier_com.ConstraintFlag.ONE_FREE_VAR,1],
+              [0.5,bezier_com.ConstraintFlag.THREE_FREE_VAR,3],[0.75,bezier_com.ConstraintFlag.THREE_FREE_VAR,3],[0.85,bezier_com.ConstraintFlag.THREE_FREE_VAR,3],[0.90,bezier_com.ConstraintFlag.THREE_FREE_VAR,3],[0.95,bezier_com.ConstraintFlag.THREE_FREE_VAR,3],[1.,bezier_com.ConstraintFlag.THREE_FREE_VAR,3],
+              [0.5,bezier_com.ConstraintFlag.FIVE_FREE_VAR,5],[0.75,bezier_com.ConstraintFlag.FIVE_FREE_VAR,5],[0.85,bezier_com.ConstraintFlag.FIVE_FREE_VAR,5],[0.90,bezier_com.ConstraintFlag.FIVE_FREE_VAR,5],[0.95,bezier_com.ConstraintFlag.FIVE_FREE_VAR,5],[1.,bezier_com.ConstraintFlag.FIVE_FREE_VAR,5]]
+# if numTry is equal to a number in this list, recompute the the limb-rrt path. This list is made such that low weight/num vars are tried for several limb-rrt path before trying higher weight/num variables
+recompute_rrt_at_tries=[0,3,6,9, 15,21,21+len(weights_vars),21+2*len(weights_vars),21+3*len(weights_vars),21+4*len(weights_vars)]
+# store the last limbRRT path ID computed        
+current_limbRRT_id = None
+
+
+
+#min (1/2)x' P x + q' x  
+#subject to  G x <= h
+#subject to  C x  = d
+def quadprog_solve_qp(P, q, G=None, h=None, C=None, d=None):
+    #~ qp_G = .5 * (P + P.T)   # make sure P is symmetric
+    qp_G = .5 * (P + P.T)   # make sure P is symmetric
+    qp_a = -q
+    if C is not None:
+        if G is not None:
+                qp_C = -vstack([C, G]).T
+                qp_b = -hstack([d, h])   
+        else:
+                qp_C = -C.transpose()
+                qp_b = -d 
+        meq = C.shape[0]
+    else:  # no equality constraint 
+        qp_C = -G.T
+        qp_b = -h
+        meq = 0
+    return quadprog.solve_qp(qp_G, qp_a, qp_C, qp_b, meq)[0]
+
 
 
 def createStateFromPhase(fullBody,q,phase):
@@ -29,7 +70,7 @@ def createStateFromPhase(fullBody,q,phase):
 
 def generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody,phaseId) :
     assert fullBody and "Cannot use limb-rrt method as fullBody object is not defined."
-    assert phaseId%2 and "Can only generate limb-rrt for 'middle' phases, ID must be odd (check generation of the contact sequence in contact_sequence/rbprm.py"
+    #assert phaseId%2 and "Can only generate limb-rrt for 'middle' phases, ID must be odd (check generation of the contact sequence in contact_sequence/rbprm.py"
     extraDof = int(fullBody.client.robot.getDimensionExtraConfigSpace())
     q_init = q_init.T.tolist()[0] + [0]*extraDof    
     q_end = q_end.T.tolist()[0] + [0]*extraDof
@@ -37,7 +78,7 @@ def generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody,ph
     # create nex states in fullBody corresponding to given configuration and set of contacts 
     s0 = createStateFromPhase(fullBody,q_init,phase_previous)
     s1 = createStateFromPhase(fullBody,q_end,phase_next)
-    if VERBOSE : 
+    if VERBOSE > 1: 
         print "New state added, q_init = ",q_init
         print "New state added, q_end = ",q_end
         contacts = fullBody.getAllLimbsInContact(s0)
@@ -52,23 +93,35 @@ def generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody,ph
         for contact in contacts : 
             effName = cfg.Robot.dict_limb_joint[contact]
             print "contact position for joint "+str(effName)+" = "+str(fullBody.getJointPosition(effName)[0:3])
-            
-    
-        
+
     # create a path in hpp corresponding to the discretized trajectory in phase :
     dt = phase.time_trajectory[1] - phase.time_trajectory[0]
     state_traj = stdVecToMatrix(phase.state_trajectory).transpose()
     control_traj = stdVecToMatrix(phase.control_trajectory).transpose()  
     c_t = state_traj[:,:3]
     v_t = state_traj[:-1,3:6]
-    a_t = control_traj[:-1,:3]
+    a_t = control_traj[:-1,:3]  
+    fullBody.setCurrentConfig(fullBody.getConfigAtState(s0))
+    com0_fb = fullBody.getCenterOfMass()
+    fullBody.setCurrentConfig(fullBody.getConfigAtState(s1))    
+    com1_fb = fullBody.getCenterOfMass()        
+     
+    ## TEST, FIXME (force com path to start/end in the com position found from q_init and q_end. :  
+    c_t[0,:] = np.matrix(com0_fb)
+    c_t[-1,:] = np.matrix(com1_fb)
+    com0 = c_t.tolist()[0]
+    com1 = c_t.tolist()[-1]      
+    if VERBOSE > 1: 
+        print "init com : ",com0_fb
+        print "init ref : ",com0
+        print "end  com : ",com1_fb
+        print "end  ref : ",com1       
+    
     path_com_id = fullBody.generateComTraj(c_t.tolist(), v_t.tolist(), a_t.tolist(), dt)
     if VERBOSE :
         print "add com reference as hpp path with id : ",path_com_id
 
     # project this states to the new COM position in phase :
-    com0 = c_t.tolist()[0]
-    com1 = c_t.tolist()[-1]
     """
     successProj=fullBody.projectStateToCOM(s0,com0)
     assert successProj and "Error during projection of state"+str(s0)+" to com position : "+str(com0)
@@ -82,15 +135,11 @@ def generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody,ph
         fullBody.setConfigAtState(s0,q_init)
         fullBody.setConfigAtState(s1,q_end)
     """
-    if VERBOSE : 
-        fullBody.setCurrentConfig(fullBody.getConfigAtState(s0))
-        print "init com : ",fullBody.getCenterOfMass()
-        print "ref      : ",com0
-        fullBody.setCurrentConfig(fullBody.getConfigAtState(s1))
-        print "end  com : ",fullBody.getCenterOfMass()
-        print "ref      : ",com1        
+
     
     # run limb-rrt in hpp : 
+    if VERBOSE : 
+        print "start limb-rrt ... "
     paths_rrt_ids = fullBody.comRRTOnePhase(s0,s1,path_com_id,10)  
     if VERBOSE :
         print "Limb-rrt returned path(s) : ",paths_rrt_ids
@@ -109,3 +158,123 @@ def generateLimbRRTTraj(time_interval,placement_init,placement_end,q_init,q_end,
 
     # TODO : make a HPPRefTraj object and return it
     return None
+
+def computeDistanceCostMatrices(fb,pathId,pData,T,eeName,numPoints = 50):
+    problem = fb.client.problem
+    # build a matrice 3xnumPoints by sampling the given path : 
+    step = problem.pathLength(pathId)/(numPoints-1);
+    pts = np.matrix(np.zeros([3,numPoints]))
+    for i in range(numPoints):
+        q = problem.configAtParam(pathId,float(step*i))
+        # compute effector pos from q : 
+        fb.setCurrentConfig(q)
+        p = fb.getJointPosition(eeName)[0:3]
+        pts[:,i] = np.matrix(p).T
+    return bezier_com.computeEndEffectorDistanceCost(pData,T,numPoints,pts)
+
+
+def generateLimbRRTOptimizedTraj(time_interval,placement_init,placement_end,q_init,q_end,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,numTry,viewer):
+    t_total = time_interval[1]-time_interval[0]
+    predef_curves = predefTraj.curves
+    bezier_takeoff = predef_curves.curves[predef_curves.idFirstNonZero()]
+    bezier_landing = predef_curves.curves[predef_curves.idLastNonZero()]
+    id_middle = int(math.floor(len(predef_curves.curves)/2.))
+    bezier_mid_predef= predef_curves.curves[id_middle]
+    pos_init = bezier_takeoff(bezier_takeoff.max())
+    pos_end = bezier_landing(0)
+    if VERBOSE :
+        print "generateLimbRRTOptimizedTraj for phase "+str(phaseId)+" try number "+str(numTry)
+        print "bezier takeoff end : ",pos_init
+        print "bezier landing init : ",pos_end
+    t_begin = predef_curves.times[id_middle]
+    t_middle = bezier_mid_predef.max()
+    t_end = t_begin + t_middle
+    if VERBOSE : 
+        print "t begin : ",t_begin
+        print "t end   : ",t_end
+        
+    global current_limbRRT_id
+    # compute new limb-rrt path if needed:
+    if not current_limbRRT_id or (numTry in recompute_rrt_at_tries):
+        current_limbRRT_id = generateLimbRRTPath(q_init,q_end,phase_previous,phase,phase_next,fullBody,phaseId)    
+        if viewer and cfg.DISPLAY_FEET_TRAJ and DISPLAY_RRT_PATH:
+            from hpp.gepetto import PathPlayer
+            pp = PathPlayer (viewer)
+            pp.displayPath(current_limbRRT_id,jointName=fullBody.getLinkNames(eeName)[0],offset =cfg.Robot.dict_offset[eeName].translation.T.tolist()[0] )        
+            
+    # find weight and number of variable to use from the numTry :
+    for offset in reversed(recompute_rrt_at_tries):
+        if numTry >= offset:
+            id = numTry - offset
+            break
+    if id > len(weights_vars):
+        raise ValueError("Max number of try allow to find a collision-end effector trajectory for phase "+str(phaseId)+" reached.")
+    weight = weights_vars[id][0]
+    varFlag = weights_vars[id][1]
+    numVars = weights_vars[id][2]
+    if VERBOSE : 
+        print "use weight "+str(weight)+" with num free var = "+str(numVars)
+    # compute constraints for the end effector trajectories : 
+    pData = bezier_com.ProblemData() 
+    pData.c0_ = bezier_takeoff(bezier_takeoff.max())
+    pData.dc0_ = bezier_takeoff.derivate(bezier_takeoff.max(),1)
+    pData.ddc0_ = bezier_takeoff.derivate(bezier_takeoff.max(),2)
+    pData.j0_ = bezier_takeoff.derivate(bezier_takeoff.max(),3)
+    pData.c1_ = bezier_landing(0)
+    pData.dc1_ = bezier_landing.derivate(0,1)
+    pData.ddc1_ = bezier_landing.derivate(0,2)
+    pData.j1_ = bezier_landing.derivate(0,3)    
+    pData.constraints_.flag_ = bezier_com.ConstraintFlag.INIT_POS | bezier_com.ConstraintFlag.INIT_VEL | bezier_com.ConstraintFlag.INIT_ACC | bezier_com.ConstraintFlag.END_ACC | bezier_com.ConstraintFlag.END_VEL | bezier_com.ConstraintFlag.END_POS | bezier_com.ConstraintFlag.INIT_JERK | bezier_com.ConstraintFlag.END_JERK | varFlag
+    Constraints = bezier_com.computeEndEffectorConstraints(pData,t_middle)
+    Cost_smooth = bezier_com.computeEndEffectorVelocityCost(pData,t_middle)
+    Cost_distance = computeDistanceCostMatrices(fullBody,current_limbRRT_id,pData,t_middle,eeName)
+    # formulate QP matrices :
+    # _ prefix = previous notation (in bezier_com_traj)
+    # min        x' H x + 2 g' x
+    # subject to A*x <= b    
+    _A = Constraints.A
+    _b = Constraints.b
+    _H = ((1.-weight)*Cost_smooth.A + weight*Cost_distance.A)
+    _g = ((1.-weight)*Cost_smooth.b + weight*Cost_distance.b) 
+    if VERBOSE > 1:
+        print "A = ",_A
+        print "b = ",_b
+        print "H = ",_H
+        print "h = ",_g
+    
+    # quadprog notation : 
+    #min (1/2)x' P x + q' x  
+    #subject to  G x <= h
+    #subject to  C x  = d
+    G = _A
+    h = _b.flatten()
+    P = _H * 2.
+    q = (_g *2.).flatten()
+    # solve the QP :
+    solved = False
+    try :
+        res = quadprog_solve_qp(P,q,G,h)
+        solved = True
+    except ValueError, e:
+        print "Quadprog error : "
+        print e.message
+        raise ValueError("Quadprog failed to solve QP for optimized limb-RRT end-effector trajectory, at phase "+str(phaseId)+" for try number "+str(numTry))              
+    
+    # build a bezier curve from the result of quadprog : 
+    vars = np.split(res,numVars) 
+    wps = bezier_com.computeEndEffectorConstantWaypoints(pData,t_middle) # one wp per column 
+    id_firstVar = 4 # depend on the flag defined above, but for end effector we always use this ones ... 
+    i=id_firstVar
+    for x in vars:
+        wps[:,i] = x
+        i +=1
+    bezier_middle = bezier(wps,t_middle)    
+    # create concatenation with takeoff/landing 
+    curves = predef_curves.curves[::]
+    curves[id_middle] = bezier_middle
+    pBezier = PolyBezier(curves)
+    if VERBOSE :
+        print "time interval     = ",time_interval[1]-time_interval[0]
+        print "polybezier length = ",pBezier.max()
+    ref_traj = trajectories.BezierTrajectory(pBezier,placement_init,placement_end,time_interval)    
+    return ref_traj        

--- a/scripts/mlp/end_effector/limb_rrt.py
+++ b/scripts/mlp/end_effector/limb_rrt.py
@@ -18,7 +18,7 @@ eigenpy.switchToNumpyArray()
 from mlp.utils import trajectories
 
 
-VERBOSE = 2
+VERBOSE = 1
 DISPLAY_RRT_PATH = True
 DISPLAY_JOINT_LEVEL = True
 # order to try weight values and number of variables : 
@@ -173,7 +173,7 @@ def computeDistanceCostMatrices(fb,pathId,pData,T,eeName,numPoints = 50):
     return bezier_com.computeEndEffectorDistanceCost(pData,T,numPoints,pts)
 
 
-def generateLimbRRTOptimizedTraj(time_interval,placement_init,placement_end,q_init,q_end,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,numTry,viewer):
+def generateLimbRRTOptimizedTraj(time_interval,placement_init,placement_end,q_t,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,numTry,viewer):
     t_total = time_interval[1]-time_interval[0]
     predef_curves = predefTraj.curves
     bezier_takeoff = predef_curves.curves[predef_curves.idFirstNonZero()]
@@ -192,7 +192,8 @@ def generateLimbRRTOptimizedTraj(time_interval,placement_init,placement_end,q_in
     if VERBOSE : 
         print "t begin : ",t_begin
         print "t end   : ",t_end
-        
+    q_init = q_t[:,int(t_begin/cfg.IK_dt)] # after the predef takeoff
+    q_end = q_t[:,int(t_end/cfg.IK_dt)]        
     global current_limbRRT_id
     # compute new limb-rrt path if needed:
     if not current_limbRRT_id or (numTry in recompute_rrt_at_tries):

--- a/scripts/mlp/end_effector/limb_rrt.py
+++ b/scripts/mlp/end_effector/limb_rrt.py
@@ -159,8 +159,7 @@ def generateLimbRRTTraj(time_interval,placement_init,placement_end,numTry,q_t,ph
         pp = PathPlayer (viewer)
         pp.displayPath(pathId,jointName=fullBody.getLinkNames(eeName)[0])
 
-    # TODO : make a HPPRefTraj object and return it
-    return None
+    return trajectories.HPPEffectorTrajectory(eeName,fullBody,fullBody.client.problem,pathId)
 
 def computeDistanceCostMatrices(fb,pathId,pData,T,eeName,numPoints = 50):
     problem = fb.client.problem

--- a/scripts/mlp/utils/plot.py
+++ b/scripts/mlp/utils/plot.py
@@ -228,10 +228,6 @@ def plotALLFromWB(cs,res,display=True,save=False,path=None):
         plotEffectorError(res.t_t,res.phases_intervals,res.effector_tracking_error)        
     plotContactForces(res.t_t,res.phases_intervals,res.contact_normal_force,res.N)
     # compute zmp from whole body or centroidal (only if it hasn't been computed already)
-    if not res.zmp_t.any():
-        computeZMP(cs,res)
-    if not res.zmp_reference.any():
-        computeZMPRef(cs,res)
     plotZMP(cs,res.zmp_t,res.zmp_reference,res.c_t)
     if display:
         plt.show(block = False)

--- a/scripts/mlp/utils/plot.py
+++ b/scripts/mlp/utils/plot.py
@@ -74,19 +74,36 @@ def plotEffectorRef(dict_refs,dt):
                 ax_sub.set_xlabel('time (s)')
                 ax_sub.set_ylabel(labels[i*3 + j])
                 ax_sub.grid(True)
-    #show_non_blocking(plt)
-    
 
-def plotEffectorError(timeline,p_intervals,eff_error_dict):
+def plotEffectorTraj(timeline,p_intervals,ref_dict,traj_dict):
     labels=["x (m)" , "y (m)" ,"z (m)"]
     colors = ['r','g','b']    
-    for eeName,error in eff_error_dict.iteritems():
+    for eeName,traj in traj_dict.iteritems():
+        fig, ax = plt.subplots(3,1)
+        fig.canvas.set_window_title("Effector trajectory (dashed = reference) : "+eeName)
+        fig.suptitle("Effector trajectory (dashed = reference) : "+eeName, fontsize=20)    
+        for i in range(3): # line = x,y,z
+                ax_sub = ax[i]
+                ax_sub.plot(timeline.T, traj[i,:].T, color=colors[i])
+                ax_sub.plot(timeline.T, ref_dict[eeName][i,:].T, color=colors[i],linestyle=":")                
+                ax_sub.set_xlabel('time (s)')
+                ax_sub.set_ylabel(labels[i])
+                ax_sub.yaxis.grid()    
+                addVerticalLineContactSwitch(timeline.T,p_intervals,ax_sub)
+
+    
+
+def plotEffectorError(timeline,p_intervals,ref_dict,traj_dict):
+    labels=["x (m)" , "y (m)" ,"z (m)"]
+    colors = ['r','g','b']    
+    for eeName,traj in traj_dict.iteritems():
+        ref = ref_dict[eeName]
         fig, ax = plt.subplots(3,1)
         fig.canvas.set_window_title("Effector tracking error : "+eeName)
         fig.suptitle("Effector tracking error : "+eeName, fontsize=20)    
         for i in range(3): # line = x,y,z
                 ax_sub = ax[i]
-                ax_sub.plot(timeline.T, error[i,:].T, color=colors[i])
+                ax_sub.plot(timeline.T, traj[i,:].T - ref[i,:].T, color=colors[i])
                 ax_sub.set_xlabel('time (s)')
                 ax_sub.set_ylabel(labels[i])
                 ax_sub.yaxis.grid()    
@@ -133,23 +150,6 @@ def plotZMP(cs,ZMP_t,ZMP_ref,pcom_t):
             circle_l = plt.Circle((pos[0], pos[1]), 0.01, color='g', fill=False)      
             ax.add_artist(circle_l)
       
-def plotEffectorTraj(timeline,p_intervals,ref_dict,traj_dict):
-    labels=["x (m)" , "y (m)" ,"z (m)"]
-    colors = ['r','g','b']    
-    for eeName,traj in traj_dict.iteritems():
-        fig, ax = plt.subplots(3,1)
-        fig.canvas.set_window_title("Effector trajectory (dashed = reference) : "+eeName)
-        fig.suptitle("Effector trajectory (dashed = reference) : "+eeName, fontsize=20)    
-        for i in range(3): # line = x,y,z
-                ax_sub = ax[i]
-                ax_sub.plot(timeline.T, traj[i,:].T, color=colors[i])
-                ax_sub.plot(timeline.T, ref_dict[eeName][i,:].T, color=colors[i],linestyle=":")                
-                ax_sub.set_xlabel('time (s)')
-                ax_sub.set_ylabel(labels[i])
-                ax_sub.yaxis.grid()    
-                addVerticalLineContactSwitch(timeline.T,p_intervals,ax_sub)
-
-    
 def plotCOMTraj(timeline,p_intervals,ref_c,ref_dc,ref_ddc,c_t,dc_t,ddc_t):
     labels=["x (m)" , "y (m)" ,"z (m)", "dx (m/s)" , "dy (m/s)" ,"dz (m/s)","ddx (m/s^2)" , "ddy (m/s^2)" ,"ddz (m/s^2)"]
     colors = ['r','g','b']    
@@ -219,13 +219,12 @@ def plotALLFromWB(cs,res,display=True,save=False,path=None):
     print "Plotting ..."
     plt.rcParams['axes.linewidth'] = plt.rcParams['font.size'] / 30.
     plt.rcParams['lines.linewidth'] = plt.rcParams['font.size'] / 30.    
-    if res.effector_trajectories.values()[0].any():
-        plotEffectorTraj(res.t_t,res.phases_intervals,res.effector_references,res.effector_trajectories)
     if res.c_t.any():
         plotCOMTraj(res.t_t,res.phases_intervals,res.c_reference,res.dc_reference,res.ddc_reference,res.c_t,res.dc_t,res.ddc_t)
-    if res.c_tracking_error.any() : 
-        plotCOMError(res.t_t,res.phases_intervals,res.c_tracking_error)
-        plotEffectorError(res.t_t,res.phases_intervals,res.effector_tracking_error)        
+        plotCOMError(res.t_t,res.phases_intervals,res.c_t - res.c_reference)        
+    if res.effector_trajectories.values()[0].any():
+        plotEffectorTraj(res.t_t,res.phases_intervals,res.effector_references,res.effector_trajectories)    
+        plotEffectorError(res.t_t,res.phases_intervals,res.effector_references,res.effector_trajectories)        
     plotContactForces(res.t_t,res.phases_intervals,res.contact_normal_force,res.N)
     # compute zmp from whole body or centroidal (only if it hasn't been computed already)
     plotZMP(cs,res.zmp_t,res.zmp_reference,res.c_t)

--- a/scripts/mlp/utils/plot.py
+++ b/scripts/mlp/utils/plot.py
@@ -124,6 +124,20 @@ def plotCOMError(timeline,p_intervals,error):
             ax_sub.yaxis.grid()    
             addVerticalLineContactSwitch(timeline.T,p_intervals,ax_sub)
 
+def plotAMError(timeline,p_intervals,error):
+    labels=["x" , "y" ,"z"]
+    colors = ['r','g','b']
+    fig, ax = plt.subplots(3,1)
+    fig.canvas.set_window_title("AM tracking error")
+    fig.suptitle("AM tracking error", fontsize=20)    
+    for i in range(3): # line = x,y,z
+            ax_sub = ax[i]
+            ax_sub.plot(timeline.T, error[i,:].T, color=colors[i])
+            ax_sub.set_xlabel('time (s)')
+            ax_sub.set_ylabel(labels[i])
+            ax_sub.yaxis.grid()    
+            addVerticalLineContactSwitch(timeline.T,p_intervals,ax_sub)
+
 
 def plotZMP(cs,ZMP_t,ZMP_ref,pcom_t):
     fig = plt.figure("ZMP-CoM (xy)")
@@ -173,7 +187,25 @@ def plotCOMTraj(timeline,p_intervals,ref_c,ref_dc,ref_ddc,c_t,dc_t,ddc_t):
             ax_sub.yaxis.grid()    
             addVerticalLineContactSwitch(timeline.T,p_intervals,ax_sub)
             
-    return
+def plotAMTraj(timeline,p_intervals,L_t,dL_t,L_reference,dL_reference):
+    labels=["x" , "y" ,"z", "dx" , "dy" ,"dz"]
+    colors = ['r','g','b']    
+    fig, ax = plt.subplots(2,3)
+    fig.canvas.set_window_title("AM trajectory (dashed = reference)")
+    fig.suptitle("AM trajectory (dashed = reference)", fontsize=20)
+    for i in range(2): # line = L,dL
+        for j in range(3): # col = x,y,z
+            ax_sub = ax[i,j]
+            if i == 0 :
+                ax_sub.plot(timeline.T, L_t[j,:].T, color=colors[j])
+                ax_sub.plot(timeline.T, L_reference[j,:].T, color=colors[j],linestyle=":")
+            elif i == 1 :
+                ax_sub.plot(timeline.T, dL_t[j,:].T, color=colors[j])
+                ax_sub.plot(timeline.T, dL_reference[j,:].T, color=colors[j],linestyle=":")                                                
+            ax_sub.set_xlabel('time (s)')
+            ax_sub.set_ylabel(labels[i*3 + j])
+            ax_sub.yaxis.grid()    
+            addVerticalLineContactSwitch(timeline.T,p_intervals,ax_sub)
 
 def plotContactForces(timeline,p_intervals,forces_dict,N):
     colors = ['r','g','b','y']  
@@ -222,6 +254,9 @@ def plotALLFromWB(cs,res,display=True,save=False,path=None):
     if res.c_t.any():
         plotCOMTraj(res.t_t,res.phases_intervals,res.c_reference,res.dc_reference,res.ddc_reference,res.c_t,res.dc_t,res.ddc_t)
         plotCOMError(res.t_t,res.phases_intervals,res.c_t - res.c_reference)        
+    if res.dL_t.any():
+        plotAMTraj(res.t_t,res.phases_intervals,res.L_t,res.dL_t,res.L_reference,res.dL_reference) 
+        plotAMError(res.t_t,res.phases_intervals,res.L_t - res.L_reference)                
     if res.effector_trajectories.values()[0].any():
         plotEffectorTraj(res.t_t,res.phases_intervals,res.effector_references,res.effector_trajectories)    
         plotEffectorError(res.t_t,res.phases_intervals,res.effector_references,res.effector_trajectories)        

--- a/scripts/mlp/utils/trajectories.py
+++ b/scripts/mlp/utils/trajectories.py
@@ -703,4 +703,23 @@ class TrajectorySE3LinearInterp(RefTrajectory):
     self.M.rotation = (self.quat0.slerp(u,self.quat1)).matrix()  
     return self.M, self.v, self.a
     
-    
+
+class HPPEffectorTrajectory (RefTrajectory):
+
+  def __init__ (self,eeName,fullBody,problem,pid,name = "HPP-effector-trajectory"):
+    RefTrajectory.__init__(self,name)
+    self._dim = 3
+    self._eeName = eenName
+    self._fb = fullBody
+    self._problem = problem
+    self._pid = pid
+    self._length = problem.pathLength(pid)
+
+  def __call__ (self, t):
+    if t < 0. : 
+      print "Trajectory called with negative time."
+      t = 0.
+    elif t > self._length:
+      print "Trajectory called after final time."
+      t = self._length    
+    return effectorPositionFromHPPPath(self._fb,self._problem,self._eeName,self._pid,t)

--- a/scripts/mlp/utils/util.py
+++ b/scripts/mlp/utils/util.py
@@ -65,6 +65,15 @@ def stdVecToMatrix(std_vector):
     res = np.hstack(tuple(vec_l))
     return res
 
+## helper method to deal with StateVectorState and other exposed c++ vectors : 
+# replace vec[i] with value if it already exist or append the value
+def appendOrReplace(vec,i,value):
+    assert len(vec) >= i , "There is an uninitialized gap in the vector."
+    if i < len(vec) :
+        vec[i] = value
+    else :
+        vec.append(value)
+
 def numpy2DToList(m):
     l = []
     for i in range(m.shape[1]):
@@ -218,3 +227,8 @@ def genSplinesForPhase(phase,init_control = None, final_control = None):
     return phase
 
 
+def copyPhaseContacts(phase_in,phase_out):
+    phase_out.RF_patch = phase_in.RF_patch
+    phase_out.LF_patch = phase_in.LF_patch
+    phase_out.RH_patch = phase_in.RH_patch
+    phase_out.LH_patch = phase_in.LH_patch

--- a/scripts/mlp/utils/util.py
+++ b/scripts/mlp/utils/util.py
@@ -232,3 +232,33 @@ def copyPhaseContacts(phase_in,phase_out):
     phase_out.LF_patch = phase_in.LF_patch
     phase_out.RH_patch = phase_in.RH_patch
     phase_out.LH_patch = phase_in.LH_patch
+
+
+
+
+def createStateFromPhase(fullBody,phase,q = None):
+    if q is None:
+        q = hppConfigFromMatrice(fullBody.client.robot,phase.reference_configurations[0])
+    contacts = []
+    if phase.RF_patch.active:
+        contacts += [cfg.Robot.rLegId]
+    if phase.LF_patch.active:
+        contacts += [cfg.Robot.lLegId]
+    if phase.RH_patch.active:
+        contacts += [cfg.Robot.rArmId]
+    if phase.LH_patch.active:
+        contacts += [cfg.Robot.lArmId]
+    return fullBody.createState(q,contacts)
+
+def hppConfigFromMatrice(robot,q_matrix):
+    q = q_matrix.T.tolist()[0]
+    extraDof = robot.getConfigSize() - q_matrix.shape[0]
+    assert extraDof >= 0 , "Changes in the robot model happened."
+    if extraDof > 0:
+        q += [0]*extraDof
+    return q
+
+def phasesHaveSameConfig(p0,p1):
+    assert len(p0.reference_configurations) > 0 and "CS object given to croc method should store one reference_configuration in each contact_phase"
+    assert len(p1.reference_configurations) > 0 and "CS object given to croc method should store one reference_configuration in each contact_phase"
+    return np.array_equal(p0.reference_configurations[0],p1.reference_configurations[0])

--- a/scripts/mlp/utils/util.py
+++ b/scripts/mlp/utils/util.py
@@ -144,3 +144,9 @@ def isContactEverActive(cs,eeName):
             raise Exception("Unknown effector name") 
     return False
     
+def effectorPositionFromHPPPath(fb,problem,eeName,pid,t):
+    q = problem.configAtParam(pid,t)
+    # compute effector pos from q : 
+    fb.setCurrentConfig(q)
+    p = fb.getJointPosition(eeName)[0:3] 
+    return np.matrix(p).T

--- a/scripts/mlp/utils/wholebody_result.py
+++ b/scripts/mlp/utils/wholebody_result.py
@@ -2,7 +2,7 @@ import numpy as np
 class Result:
     
     
-    def __init__(self,nq,nv,dt,eeNames,N=None,cs=None,t_begin = 0):
+    def __init__(self,nq,nv,dt,eeNames,N=None,cs=None,t_begin = 0,nu = None):
         self.dt = dt
         if cs :
             self.N = int(round(cs.contact_phases[-1].time_trajectory[-1]/self.dt)) + 1             
@@ -13,11 +13,14 @@ class Result:
         N = self.N
         self.nq = nq
         self.nv = nv
+        if not nu : 
+            nu = nv -6 
+        self.nu = nu
         self.t_t = np.array([t_begin + i*self.dt for i in range(N)])
         self.q_t = np.matrix(np.zeros([self.nq,N]))
         self.dq_t = np.matrix(np.zeros([self.nv,N]))
         self.ddq_t = np.matrix(np.zeros([self.nv,N]))
-        self.tau_t = np.matrix(np.zeros([self.nv,N]))
+        self.tau_t = np.matrix(np.zeros([self.nu,N]))
         self.c_t = np.matrix(np.zeros([3,N]))  
         self.dc_t = np.matrix(np.zeros([3,N]))
         self.ddc_t = np.matrix(np.zeros([3,N]))
@@ -140,7 +143,7 @@ class Result:
         if not os.path.exists(path):
             os.makedirs(path)
         filename = path+"/"+name       
-        np.savez_compressed(filename,N=self.N,nq=self.nq,nv=self.nv,dt=self.dt,t_t=self.t_t,
+        np.savez_compressed(filename,N=self.N,nq=self.nq,nv=self.nv,nu = self.nu,dt=self.dt,t_t=self.t_t,
                  q_t=self.q_t,dq_t=self.dq_t,ddq_t=self.ddq_t,tau_t=self.tau_t,
                  c_t=self.c_t,dc_t=self.dc_t,ddc_t=self.ddc_t,L_t=self.L_t,dL_t=self.dL_t,
                  c_reference=self.c_reference,dc_reference=self.dc_reference,ddc_reference=self.ddc_reference,
@@ -157,9 +160,10 @@ def loadFromNPZ(filename):
     N = f['N'].tolist()
     nq = f['nq'].tolist()
     nv = f['nv'].tolist()
+    nu = f['nu'].tolist()
     dt = f['dt'].tolist()
     eeNames = f['eeNames'].tolist()
-    res = Result(nq,nv,dt,eeNames=eeNames,N=N)
+    res = Result(nq,nv,dt,eeNames=eeNames,N=N,nu=nu)
     res.t_t = f['t_t']
     res.q_t  =np.asmatrix(f['q_t'])
     res.dq_t =np.asmatrix(f['dq_t'])

--- a/scripts/mlp/utils/wholebody_result.py
+++ b/scripts/mlp/utils/wholebody_result.py
@@ -23,7 +23,6 @@ class Result:
         self.ddc_t = np.matrix(np.zeros([3,N]))
         self.L_t = np.matrix(np.zeros([3,N]))
         self.dL_t = np.matrix(np.zeros([3,N]))
-        self.c_tracking_error = np.matrix(np.zeros([3,N]))
         self.c_reference = np.matrix(np.zeros([3,N]))
         self.dc_reference = np.matrix(np.zeros([3,N]))
         self.ddc_reference = np.matrix(np.zeros([3,N])) 
@@ -38,14 +37,12 @@ class Result:
         self.contact_normal_force={}
         self.effector_trajectories = {}
         self.effector_references = {}
-        self.effector_tracking_error = {}
         self.contact_activity = {}
         for ee in self.eeNames : 
             self.contact_forces.update({ee:np.matrix(np.zeros([12,N]))}) 
             self.contact_normal_force.update({ee:np.matrix(np.zeros([1,N]))})              
             self.effector_trajectories.update({ee:np.matrix(np.zeros([12,N]))}) 
             self.effector_references.update({ee:np.matrix(np.zeros([12,N]))})
-            self.effector_tracking_error.update({ee:np.matrix(np.zeros([6,N]))})
             self.contact_activity.update({ee:np.matrix(np.zeros([1,N]))})
         if cs:
             self.phases_intervals = self.buildPhasesIntervals(cs)    
@@ -91,7 +88,6 @@ class Result:
         self.ddc_t[:,k] =other.ddc_t[:,k_other]
         self.L_t[:,k] =other.L_t[:,k_other]
         self.dL_t[:,k] =other.dL_t[:,k_other]
-        self.c_tracking_error[:,k] =other.c_tracking_error[:,k_other]
         self.c_reference[:,k] =other.c_reference[:,k_other]
         self.dc_reference[:,k] =other.dc_reference[:,k_other] 
         self.ddc_reference[:,k] =other.ddc_reference[:,k_other]
@@ -106,7 +102,6 @@ class Result:
             self.contact_normal_force[ee][:,k] = other.contact_normal_force[ee][:,k_other]            
             self.effector_trajectories[ee][:,k] =other.effector_trajectories[ee][:,k_other]
             self.effector_references[ee][:,k] =other.effector_references[ee][:,k_other]
-            self.effector_tracking_error[ee][:,k] =other.effector_tracking_error[ee][:,k_other]
             self.contact_activity[ee][:,k] =other.contact_activity[ee][:,k_other]
     
             
@@ -122,7 +117,6 @@ class Result:
         self.ddc_t = self.ddc_t[:,:N]
         self.L_t = self.L_t[:,:N]
         self.dL_t = self.dL_t[:,:N]
-        self.c_tracking_error = self.c_tracking_error[:,:N]
         self.c_reference = self.c_reference[:,:N]
         self.dc_reference = self.dc_reference[:,:N]
         self.ddc_reference = self.ddc_reference[:,:N]
@@ -137,7 +131,6 @@ class Result:
             self.contact_normal_force[ee] = self.contact_normal_force[ee][:,:N]                            
             self.effector_trajectories[ee] = self.effector_trajectories[ee][:,:N] 
             self.effector_references[ee] = self.effector_references[ee][:,:N] 
-            self.effector_tracking_error[ee] = self.effector_tracking_error[ee][:,:N]
             self.contact_activity[ee] = self.contact_activity[ee][:,:N]
         self.phases_intervals = self.resizePhasesIntervals(N)
         return self
@@ -150,11 +143,11 @@ class Result:
         np.savez_compressed(filename,N=self.N,nq=self.nq,nv=self.nv,dt=self.dt,t_t=self.t_t,
                  q_t=self.q_t,dq_t=self.dq_t,ddq_t=self.ddq_t,tau_t=self.tau_t,
                  c_t=self.c_t,dc_t=self.dc_t,ddc_t=self.ddc_t,L_t=self.L_t,dL_t=self.dL_t,
-                 c_tracking_error=self.c_tracking_error,c_reference=self.c_reference,dc_reference=self.dc_reference,ddc_reference=self.ddc_reference,
+                 c_reference=self.c_reference,dc_reference=self.dc_reference,ddc_reference=self.ddc_reference,
                  L_reference=self.L_reference,dL_reference=self.dL_reference,
                  wrench_t=self.wrench_t,zmp_t=self.zmp_t,wrench_reference=self.wrench_reference,zmp_reference=self.zmp_reference,
                  eeNames=self.eeNames,contact_forces=self.contact_forces,contact_normal_force=self.contact_normal_force,
-                 effector_trajectories=self.effector_trajectories,effector_references=self.effector_references,effector_tracking_error=self.effector_tracking_error,
+                 effector_trajectories=self.effector_trajectories,effector_references=self.effector_references,
                  contact_activity=self.contact_activity,phases_intervals=self.phases_intervals)
         
         print "Results exported to ",filename
@@ -177,7 +170,6 @@ def loadFromNPZ(filename):
     res.ddc_t =np.asmatrix(f['ddc_t'])
     res.L_t =np.asmatrix(f['L_t'])
     res.dL_t =np.asmatrix(f['dL_t'])
-    res.c_tracking_error =np.asmatrix(f['c_tracking_error'])
     res.c_reference =np.asmatrix(f['c_reference'])
     res.dc_reference =np.asmatrix(f['dc_reference'])
     res.ddc_reference =np.asmatrix(f['ddc_reference'])
@@ -191,7 +183,6 @@ def loadFromNPZ(filename):
     res.contact_normal_force = f['contact_normal_force'].tolist()            
     res.effector_trajectories =f['effector_trajectories'].tolist()
     res.effector_references =f['effector_references'].tolist()
-    res.effector_tracking_error =f['effector_tracking_error'].tolist()
     res.contact_activity =f['contact_activity'].tolist()
     res.phases_intervals = f['phases_intervals'].tolist()
     f.close()
@@ -200,6 +191,5 @@ def loadFromNPZ(filename):
         res.contact_normal_force[ee] = np.asmatrix(res.contact_normal_force[ee])                           
         res.effector_trajectories[ee] = np.asmatrix(res.effector_trajectories[ee])
         res.effector_references[ee] = np.asmatrix(res.effector_references[ee])
-        res.effector_tracking_error[ee] = np.asmatrix(res.effector_tracking_error[ee])
         res.contact_activity[ee] = np.asmatrix(res.contact_activity[ee])   
     return res

--- a/scripts/mlp/utils/wholebody_result.py
+++ b/scripts/mlp/utils/wholebody_result.py
@@ -17,7 +17,7 @@ class Result:
         self.q_t = np.matrix(np.zeros([self.nq,N]))
         self.dq_t = np.matrix(np.zeros([self.nv,N]))
         self.ddq_t = np.matrix(np.zeros([self.nv,N]))
-        self.tau_t = np.matrix(np.zeros([self.nv-6,N]))
+        self.tau_t = np.matrix(np.zeros([self.nv,N]))
         self.c_t = np.matrix(np.zeros([3,N]))  
         self.dc_t = np.matrix(np.zeros([3,N]))
         self.ddc_t = np.matrix(np.zeros([3,N]))

--- a/scripts/mlp/utils/wholebody_result.py
+++ b/scripts/mlp/utils/wholebody_result.py
@@ -154,6 +154,11 @@ class Result:
                  contact_activity=self.contact_activity,phases_intervals=self.phases_intervals)
         
         print "Results exported to ",filename
+        
+    def qAtT(self,t):
+        k = int(round(t/self.dt))
+        assert self.t_t[k] == t and "Error in computation of time in Result struct."
+        return self.q_t[:,k]
 
 def loadFromNPZ(filename):
     f=np.load(filename)

--- a/scripts/mlp/viewer/display_tools.py
+++ b/scripts/mlp/viewer/display_tools.py
@@ -197,4 +197,4 @@ def initScene(Robot,envName = "multicontact/ground"):
   vf.loadObstacleModel ("hpp_environments", envName, "planning")
   v = vf.createViewer( displayCoM = True)
   v(fullBody.getCurrentConfig())
-  return v,fullBody    
+  return fullBody,v    

--- a/scripts/mlp/viewer/display_tools.py
+++ b/scripts/mlp/viewer/display_tools.py
@@ -141,7 +141,10 @@ def displaySE3Traj(traj,viewer,name,color,time_interval,offset=SE3.Identity()):
     viewer.client.gui.refresh()
     
 def displayWBconfig(viewer,q_matrix):
-  viewer(hppConfigFromMatrice(viewer.robot,q_matrix))  
+  viewer(hppConfigFromMatrice(viewer.robot,q_matrix))
+  
+def displayWBatT(viewer,res,t):
+  viewer(hppConfigFromMatrice(viewer.robot,res.qAtT(t)))
     
 def displayWBmotion(viewer,q_t,dt,dt_display):
     id = 0

--- a/scripts/mlp/viewer/display_tools.py
+++ b/scripts/mlp/viewer/display_tools.py
@@ -5,7 +5,7 @@ import multicontact_api
 from multicontact_api import WrenchCone,SOC6,ContactPatch, ContactPhaseHumanoid, ContactSequenceHumanoid
 import numpy as np
 import time
-from mlp.utils.util import stdVecToMatrix,numpy2DToList
+from mlp.utils.util import stdVecToMatrix,numpy2DToList,hppConfigFromMatrice
 STONE_HEIGHT = 0.005
 STONE_GROUP = "stepping_stones"        
 TRAJ_GROUP = "com_traj"
@@ -141,12 +141,7 @@ def displaySE3Traj(traj,viewer,name,color,time_interval,offset=SE3.Identity()):
     viewer.client.gui.refresh()
     
 def displayWBconfig(viewer,q_matrix):
-  q = q_matrix.T.tolist()[0]
-  extraDof = viewer.robot.getConfigSize() - q_matrix.shape[0]
-  assert extraDof >= 0 , "Robot model used by the IK is not the same as during the planning"
-  if extraDof > 0:
-    q += [0]*extraDof
-  viewer(q)  
+  viewer(hppConfigFromMatrice(viewer.robot,q_matrix))  
     
 def displayWBmotion(viewer,q_t,dt,dt_display):
     id = 0

--- a/scripts/mlp/viewer/display_tools.py
+++ b/scripts/mlp/viewer/display_tools.py
@@ -191,6 +191,7 @@ def initScene(Robot,envName = "multicontact/ground"):
   from hpp.corbaserver.rbprm.rbprmfullbody import FullBody
   from hpp.corbaserver import ProblemSolver  
   fullBody = Robot ()
+  fullBody.loadAllLimbs("static",nbSamples=1)
   ps = ProblemSolver(fullBody)
   vf = ViewerFactory (ps)
   vf.loadObstacleModel ("hpp_environments", envName, "planning")

--- a/scripts/mlp/viewer/display_tools.py
+++ b/scripts/mlp/viewer/display_tools.py
@@ -179,3 +179,21 @@ def displayFeetTrajFromResult(viewer,res):
     viewer.client.gui.addCurve(name,traj,color)
     viewer.client.gui.addToGroup(name,viewer.sceneName)    
     viewer.client.gui.refresh()    
+    
+def displayContactSequence(v,cs,step = 0.2):
+  for p in cs.contact_phases:
+    displayWBconfig(v,p.reference_configurations[0])
+    time.sleep(step)  
+    
+
+def initScene(Robot,envName = "multicontact/ground"):
+  from hpp.gepetto import Viewer,ViewerFactory
+  from hpp.corbaserver.rbprm.rbprmfullbody import FullBody
+  from hpp.corbaserver import ProblemSolver  
+  fullBody = Robot ()
+  ps = ProblemSolver(fullBody)
+  vf = ViewerFactory (ps)
+  vf.loadObstacleModel ("hpp_environments", envName, "planning")
+  v = vf.createViewer( displayCoM = True)
+  v(fullBody.getCurrentConfig())
+  return v,fullBody    

--- a/scripts/mlp/wholebody/__init__.py
+++ b/scripts/mlp/wholebody/__init__.py
@@ -1,0 +1,13 @@
+import mlp.config as cfg 
+
+#wholebody_method_available = ["load", "tsid", "croccodyl"]
+method = cfg.wholebody_method
+
+if method == "load":
+    from .fromNPZfile import generateWholeBodyMotion
+elif method == "tsid":
+    from .tsid_invdyn import generateWholeBodyMotion
+elif method == "croccodyl":
+    from .croccodyl import generateWholeBodyMotion    
+else : 
+    raise ValueError("method type "+str(method)+" doesn't exist for wholeBody motion generation")

--- a/scripts/mlp/wholebody/croccodyl.py
+++ b/scripts/mlp/wholebody/croccodyl.py
@@ -1,0 +1,4 @@
+import mlp.config as cfg
+
+def generateWholeBodyMotion(cs,fullBody=None,viewer=None):
+    raise NotImplemented("TODO")

--- a/scripts/mlp/wholebody/fromNPZfile.py
+++ b/scripts/mlp/wholebody/fromNPZfile.py
@@ -1,0 +1,17 @@
+import mlp.config as cfg
+from rospkg import RosPack
+from mlp.utils import wholebody_result
+
+def generateWholeBodyMotion(cs,fullBody=None,viewer=None):
+    rp = RosPack()
+    urdf = rp.get_path(cfg.Robot.packageName)+'/urdf/'+cfg.Robot.urdfName+cfg.Robot.urdfSuffix+'.urdf'
+    if cfg.WB_VERBOSE:
+        print "load robot : " ,urdf 
+    pinRobot  = pin.RobotWrapper.BuildFromURDF(urdf, pin.StdVec_StdString(), pin.JointModelFreeFlyer(), False)        
+    if cfg.WB_VERBOSE:
+        print "robot loaded."
+    filename = cfg.EXPORT_PATH+"/npz",cfg.DEMO_NAME+".npz"
+    print "Load npz file : ",filename
+    res = wholebody_result.loadFromNPZ(filename)
+    return res,robot
+    

--- a/scripts/mlp/wholebody/tsid_invdyn.py
+++ b/scripts/mlp/wholebody/tsid_invdyn.py
@@ -261,12 +261,7 @@ def generateWholeBodyMotion(cs,viewer=None,fullBody=None):
                 res.zmp_reference[:,k_t] = shiftZMPtoFloorAltitude(cs,res.t_t[k_t],F0)
         if cfg.IK_store_effector: 
             for eeName in usedEffectors: # real position (not reference)
-                res.effector_trajectories[eeName][:,k_t] = SE3toVec(robot.position(invdyn.data(), robot.model().getJointId(eeName)))
-        # store tracking error : 
-        if cfg.IK_store_error : 
-            res.c_tracking_error[:,k_t] = comTask.position_error
-            for eeName,task in dic_effectors_tasks.iteritems():
-                res.effector_tracking_error[eeName][:,k_t] = task.position_error                  
+                res.effector_trajectories[eeName][:,k_t] = SE3toVec(robot.position(invdyn.data(), robot.model().getJointId(eeName)))        
         return res
         
     def printIntermediate(v,dv,invdyn,sol):

--- a/scripts/mlp/wholebody/tsid_invdyn.py
+++ b/scripts/mlp/wholebody/tsid_invdyn.py
@@ -78,16 +78,16 @@ def generateEEReferenceTraj(robot,robotData,time_interval,phase,phase_next,eeNam
         print "positions : ",placements        
     return ref_traj
 
-def generateEEReferenceTrajCollisionFree(fullBody,robot,robotData,time_interval,phase_previous,phase,phase_next,q_init,q_end,predefTraj,eeName,phaseId,numTry,viewer = None):
+def generateEEReferenceTrajCollisionFree(fullBody,robot,robotData,time_interval,phase_previous,phase,phase_next,q_t,predefTraj,eeName,phaseId,numTry,viewer = None):
     placements = []
     placement_init = JointPlacementForEffector(phase_previous,eeName)
     placement_end = JointPlacementForEffector(phase_next,eeName)
     placements.append(placement_init)
     placements.append(placement_end)
     if cfg.USE_CONSTRAINED_BEZIER :
-        ref_traj = bezier_constrained.generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_init,q_end,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,viewer)                    
+        ref_traj = bezier_constrained.generateConstrainedBezierTraj(time_interval,placement_init,placement_end,q_t,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,viewer)                    
     elif cfg.USE_LIMB_RRT:
-        ref_traj = limb_rrt.generateLimbRRTOptimizedTraj(time_interval,placement_init,placement_end,q_init,q_end,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,numTry,viewer) 
+        ref_traj = limb_rrt.generateLimbRRTOptimizedTraj(time_interval,placement_init,placement_end,q_t,predefTraj,phase_previous,phase,phase_next,fullBody,phaseId,eeName,numTry,viewer) 
     return ref_traj
 
 def computeCOMRefFromPhase(phase,time_interval):
@@ -452,7 +452,7 @@ def generateWholeBodyMotion(cs,viewer=None,fullBody=None):
                 
             # end while t \in phase_t (loop for the current contact phase) 
             if swingPhase and cfg.EFF_CHECK_COLLISION :
-                phaseValid,t_invalid = validator.check_motion(res.q_t[:,phase_interval[0]:k_t]) #FIXME
+                phaseValid,t_invalid = validator.check_motion(res.q_t[:,phase_interval[0]:k_t])
                 #if iter_for_phase == 0:# FIXME : debug only, force limb-rrt
                 #    phaseValid = False
                 if not phaseValid :
@@ -462,7 +462,7 @@ def generateWholeBodyMotion(cs,viewer=None,fullBody=None):
                         try:
                             for eeName,oldTraj in dic_effectors_trajs.iteritems():
                                 if oldTraj: # update the traj in the map
-                                    ref_traj = generateEEReferenceTrajCollisionFree(fullBody,robot,invdyn.data(),time_interval,phase_prev,phase,phase_next,q_begin,q,oldTraj,eeName,pid,iter_for_phase,viewer)
+                                    ref_traj = generateEEReferenceTrajCollisionFree(fullBody,robot,invdyn.data(),time_interval,phase_prev,phase,phase_next,res.q_t[:,phase_interval[0]:k_t],oldTraj,eeName,pid,iter_for_phase,viewer)
                                     dic_effectors_trajs.update({eeName:ref_traj}) 
                         except ValueError,e :
                             print "ERROR in generateEEReferenceTrajCollisionFree :"

--- a/scripts/mlp/wholebody/tsid_invdyn.py
+++ b/scripts/mlp/wholebody/tsid_invdyn.py
@@ -189,7 +189,7 @@ def generateWholeBodyMotion(cs,fullBody=None,viewer=None):
         res.q_t[:,k_t] = q
         res.dq_t[:,k_t] = v                
         res.ddq_t[:,k_t] = dv                             
-        res.tau_t[6:,k_t] = invdyn.getActuatorForces(sol) # actuator forces, with external forces (contact forces)
+        res.tau_t[:,k_t] = invdyn.getActuatorForces(sol) # actuator forces, with external forces (contact forces)
         #store contact info (force and status)
         if cfg.IK_store_contact_forces :
             for eeName,contact in dic_contacts.iteritems():
@@ -215,7 +215,7 @@ def generateWholeBodyMotion(cs,fullBody=None,viewer=None):
             res.dL_reference[:,k_t] = dL_desired 
             if cfg.IK_store_zmp : 
                 tau = pin.rnea(pinRobot.model,pinRobot.data,q,v,dv) # tau without external forces, only used for the 6 first
-                res.tau_t[:6,k_t] = tau[:6]
+                #res.tau_t[:6,k_t] = tau[:6]
                 phi0 = pinRobot.data.oMi[1].act(Force(tau[:6]))
                 res.wrench_t[:,k_t] = phi0.vector
                 res.zmp_t[:,k_t] = shiftZMPtoFloorAltitude(cs,res.t_t[k_t],phi0)

--- a/scripts/mlp/wholebody/tsid_invdyn.py
+++ b/scripts/mlp/wholebody/tsid_invdyn.py
@@ -137,8 +137,8 @@ def generateWholeBodyMotion(cs,viewer=None,fullBody=None):
     robot = tsid.RobotWrapper(urdf, pin.StdVec_StdString(), pin.JointModelFreeFlyer(), False)
     if cfg.WB_VERBOSE:
         print "robot loaded in tsid"
-    if cfg.IK_store_centroidal : # FIXME : tsid robotWrapper don't have all the required methods, only pinocchio have them
-        pinRobot  = pin.RobotWrapper.BuildFromURDF(urdf, pin.StdVec_StdString(), pin.JointModelFreeFlyer(), False)
+    # FIXME : tsid robotWrapper don't have all the required methods, only pinocchio have them
+    pinRobot  = pin.RobotWrapper.BuildFromURDF(urdf, pin.StdVec_StdString(), pin.JointModelFreeFlyer(), False)
 
     q = cs.contact_phases[0].reference_configurations[0].copy()
     v = np.matrix(np.zeros(robot.nv)).transpose()
@@ -483,9 +483,9 @@ def generateWholeBodyMotion(cs,viewer=None,fullBody=None):
                             print "ERROR in generateEEReferenceTrajCollisionFree :"
                             print e.message
                             if cfg.WB_ABORT_WHEN_INVALID :
-                                return res.resize(k_begin),robot
+                                return res.resize(k_begin),pinRobot
                             elif cfg.WB_RETURN_INVALID : 
-                                return res.resize(k_t),robot                      
+                                return res.resize(k_t),pinRobot                    
                     
             else : # no effector motions, phase always valid (or bypass the check)
                 phaseValid = True
@@ -514,10 +514,10 @@ def generateWholeBodyMotion(cs,viewer=None,fullBody=None):
 
     if cfg.PLOT:
         from mlp.utils import plot
-        plot.plotEffectorRef(stored_effectors_ref,dt)            
+        plot.plotEffectorRef(stored_effectors_ref,dt)   # plot inside this file, as we have access to the real Bezier object and not only the discretization stored in 'res' struct         
     
     assert (k_t == res.N-1) and "res struct not fully filled."
-    return res,robot
+    return res,pinRobot
 
    
     

--- a/scripts/mlp/wholebody/tsid_invdyn.py
+++ b/scripts/mlp/wholebody/tsid_invdyn.py
@@ -499,7 +499,7 @@ def generateWholeBodyMotion(cs,viewer=None,fullBody=None):
 
     if cfg.PLOT:
         from mlp.utils import plot
-        plot.plotEffectorRef(stored_effectors_ref)            
+        plot.plotEffectorRef(stored_effectors_ref,dt)            
     
     assert (k_t == res.N-1) and "res struct not fully filled."
     return res,robot

--- a/scripts/mlp/wholebody/tsid_invdyn.py
+++ b/scripts/mlp/wholebody/tsid_invdyn.py
@@ -109,7 +109,7 @@ def generateWholeBodyMotion(cs,fullBody=None,viewer=None):
     # FIXME : tsid robotWrapper don't have all the required methods, only pinocchio have them
     pinRobot  = pin.RobotWrapper.BuildFromURDF(urdf, pin.StdVec_StdString(), pin.JointModelFreeFlyer(), False)
 
-    q = cs.contact_phases[0].reference_configurations[0].copy()
+    q = cs.contact_phases[0].reference_configurations[0][:robot.nq].copy()
     v = np.matrix(np.zeros(robot.nv)).transpose()
     t = 0.0  # time
     # init states list with initial state (assume joint velocity is null for t=0)

--- a/scripts/run_mlp.py
+++ b/scripts/run_mlp.py
@@ -59,7 +59,7 @@ if cfg.DISPLAY_WB_MOTION:
 
 if cfg.PLOT:
     from mlp.utils import plot
-    plot.plotKneeTorque(res.t_t,res.phases_intervals,res.tau_t,6 + (res.nq - res.nv),cfg.Robot.kneeIds)    
+    plot.plotKneeTorque(res.t_t,res.phases_intervals,res.tau_t,(res.nq - res.nu),cfg.Robot.kneeIds)    
     plot.plotALLFromWB(cs_com,res,cfg.DISPLAY_PLOT,cfg.SAVE_PLOT,cfg.OUTPUT_DIR+"/plot/"+cfg.DEMO_NAME)
     
 if cfg.EXPORT_OPENHRP and motion_valid:

--- a/scripts/run_mlp.py
+++ b/scripts/run_mlp.py
@@ -1,85 +1,66 @@
 import mlp.config as cfg
 import mlp.viewer.display_tools as display_tools
-from multicontact_api import ContactSequenceHumanoid
 
-
-if cfg.LOAD_CS:
-    import mlp.contact_sequence.fromCSfile as gen_cs
-else:
-    import mlp.contact_sequence.rbprm as gen_cs
-
-cs,fullBody,v = gen_cs.generateContactSequence()
-
-
+print "### MLP : contact sequence ###"
+from mlp.contact_sequence import generateContactSequence
+cs,fullBody,viewer = generateContactSequence()
 
 if cfg.DISPLAY_CS:
     raw_input("Press Enter to display the contact sequence ...")
-    display_tools.displayContactSequence(v,cs,step)
-    
-if cfg.SAVE_CS and not cfg.LOAD_CS:
-    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME
+    display_tools.displayContactSequence(viewer,cs,step)    
+if cfg.SAVE_CS:
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+".cs"
     print "Write contact sequence binary file : ",filename
     cs.saveAsBinary(filename)    
 if cfg.DISPLAY_CS_STONES :
-    display_tools.displaySteppingStones(cs,v)
+    display_tools.displaySteppingStones(cs,viewer)
     
-if cfg.USE_GEOM_INIT_GUESS:
-    print "Generate geometric init guess."
-    import mlp.centroidal.geometric as initGuess_geom 
-    cs_initGuess = initGuess_geom.generateCentroidalTrajectory(cs)
-if cfg.USE_CROC_INIT_GUESS:
-    print "Generate init guess with CROC."
-    import mlp.centroidal.croc as initGuess_croc    
-    cs_initGuess = initGuess_croc.generateCentroidalTrajectory(cs,fullBody,beginState,endState)
-if cfg.DISPLAY_INIT_GUESS_TRAJ and (cfg.USE_GEOM_INIT_GUESS or cfg.USE_CROC_INIT_GUESS):
-    colors = [v.color.red, v.color.yellow]
-    display_tools.displayCOMTrajectory(cs_initGuess,v,colors,"_init")
 
-if cfg.LOAD_CS_COM :
-    cs_com = ContactSequenceHumanoid(0)
-    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM"
-    cs_com.loadFromBinary(filename)     
-else:
-    import mlp.centroidal.topt as centroidal
-    cs_com,tp = centroidal.generateCentroidalTrajectory(cs,cs_initGuess,v)
-    print "Duration of the motion : "+str(cs_com.contact_phases[-1].time_trajectory[-1])+" s."
+print "------------------------------"
+print "### MLP : centroidal, initial Guess ###"
+from mlp.centroidal import generateCentroidalInitGuess
+cs_initGuess = generateCentroidalInitGuess(cs,fullBody=fullBody,viewer=viewer)
 
+if cfg.DISPLAY_INIT_GUESS_TRAJ and cs_initGuess:
+    colors = [viewer.color.red, viewer.color.yellow]
+    display_tools.displayCOMTrajectory(cs_initGuess,viewer,colors,"_init")    
 
-if cfg.SAVE_CS_COM and not cfg.LOAD_CS_COM:
-    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM.xml"
-    print "Write contact sequence with centroidal trajectory XML file : ",filename
+print "------------------------------"
+print "### MLP : centroidal  ###"
+from mlp.centroidal import generateCentroidalTrajectory
+cs_com = generateCentroidalTrajectory(cs,cs_initGuess,fullBody,viewer)
+
+if cfg.SAVE_CS_COM:
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM.cs"
+    print "Write contact sequence binary file with centroidal trajectory : ",filename
     cs_com.saveAsBinary(filename) 
 if cfg.DISPLAY_COM_TRAJ:
-    colors = [v.color.blue, v.color.green]
-    display_tools.displayCOMTrajectory(cs_com,v,colors)
-
-import mlp.wholebody.tsid_invdyn as wb
-if cfg.USE_CROC_COM:
-    assert cfg.USE_CROC_INIT_GUESS, "You must generate CROC initial guess if you want to use it as reference for the COM"  
-    res,robot = wb.generateWholeBodyMotion(cs_initGuess,v,fullBody)
-else : 
-    #q_t,v_t,a_t = wb.generateWholeBodyMotion(cs_com,v,fullBody)
-    res,robot =  wb.generateWholeBodyMotion(cs_com,v,fullBody)
-
-if cfg.DISPLAY_WB_MOTION:
-    raw_input("Press Enter to display the whole body motion ...")
-    display_tools.displayWBmotion(v,res.q_t,cfg.IK_dt,cfg.DT_DISPLAY)
+    colors = [viewer.color.blue, viewer.color.green]
+    display_tools.displayCOMTrajectory(cs_com,viewer,colors)
+    
+print "------------------------------"
+print "### MLP : whole-body  ###"
+from mlp.wholebody import generateWholeBodyMotion
+res,robot = generateWholeBodyMotion(cs_com,fullBody,viewer)
 
 if cfg.CHECK_FINAL_MOTION :
     from mlp.utils import check_path
     print "## Begin validation of the final motion (collision and joint-limits)"
-    validator = check_path.PathChecker(v,fullBody,cs_com,res.nq,True)
+    validator = check_path.PathChecker(viewer,fullBody,cs_com,res.nq,True)
     motion_valid,t_invalid = validator.check_motion(res.q_t)
     print "## Check final motion, valid = ",motion_valid
     if not motion_valid:
         print "## First invalid time : ",t_invalid
 else :
     motion_valid = True
+if cfg.DISPLAY_WB_MOTION:
+    raw_input("Press Enter to display the whole body motion ...")
+    display_tools.displayWBmotion(viewer,res.q_t,cfg.IK_dt,cfg.DT_DISPLAY)
 
 if cfg.PLOT:
     from mlp.utils import plot
+    plot.plotKneeTorque(res.t_t,res.phases_intervals,res.tau_t,6 + (res.nq - res.nv),cfg.Robot.kneeIds)    
     plot.plotALLFromWB(cs_com,res,cfg.DISPLAY_PLOT,cfg.SAVE_PLOT,cfg.OUTPUT_DIR+"/plot/"+cfg.DEMO_NAME)
-    plot.plotKneeTorque(res.t_t,res.phases_intervals,res.tau_t,6 + (res.nq - res.nv),cfg.Robot.kneeIds)
     
 if cfg.EXPORT_OPENHRP and motion_valid:
     from mlp.export import openHRP
@@ -89,19 +70,21 @@ if cfg.EXPORT_GAZEBO and motion_valid:
     gazebo.export(res.q_t)
 if cfg.EXPORT_NPZ and motion_valid :
     res.exportNPZ(cfg.EXPORT_PATH+"/npz",cfg.DEMO_NAME+".npz")
-
+if cfg.EXPORT_BLENDER:
+    from mlp.export import blender
+    blender.export(res.q_t,viewer)
 
 def dispCS(step = 0.2): 
-    display_tools.displayContactSequence(v,cs,step)
+    display_tools.displayContactSequence(viewer,cs,step)
     
 def dispWB():
-    display_tools.displayWBmotion(v,res.q_t,cfg.IK_dt,cfg.DT_DISPLAY)
+    display_tools.displayWBmotion(viewer,res.q_t,cfg.IK_dt,cfg.DT_DISPLAY)
  
 """
 #record gepetto-viewer 
-v.startCapture("capture/capture","png")
+viewer.startCapture("capture/capture","png")
 dispWB()
-v.stopCapture()
+viewer.stopCapture()
 
 
 """

--- a/scripts/run_mlp.py
+++ b/scripts/run_mlp.py
@@ -101,9 +101,13 @@ if cfg.EXPORT_BLENDER:
 def dispCS(step = 0.2): 
     display_tools.displayContactSequence(viewer,cs,step)
     
-def dispWB():
-    display_tools.displayWBmotion(viewer,res.q_t,cfg.IK_dt,cfg.DT_DISPLAY)
- 
+def dispWB(t=None):
+    if t is None:
+        display_tools.displayWBmotion(viewer,res.q_t,cfg.IK_dt,cfg.DT_DISPLAY)
+    else:
+        display_tools.displayWBatT(viewer,res,t)
+
+    
 """
 #record gepetto-viewer 
 viewer.startCapture("capture/capture","png")

--- a/scripts/run_mlp.py
+++ b/scripts/run_mlp.py
@@ -17,18 +17,18 @@ if cfg.DISPLAY_CS:
     
 if cfg.LOAD_CS:
     cs = ContactSequenceHumanoid(0)
-    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+".xml"   
-    print "Import contact sequence XML file : ",filename    
-    cs.loadFromXML(filename, "ContactSequence") 
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME   
+    print "Import contact sequence binary file : ",filename    
+    cs.loadFromBinary(filename) 
 else:
     beginState = 0
     endState = len(cp.configs) - 1
     cs = generate_cs.generateContactSequence(cp.fullBody,cp.configs,beginState,endState)
 
 if cfg.SAVE_CS and not cfg.LOAD_CS:
-    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+".xml"
-    print "Write contact sequence XML file : ",filename
-    cs.saveAsXML(filename, "ContactSequence")    
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME
+    print "Write contact sequence binary file : ",filename
+    cs.saveAsBinary(filename)    
 if cfg.DISPLAY_CS_STONES :
     display_tools.displaySteppingStones(cs,v)
     
@@ -46,8 +46,8 @@ if cfg.DISPLAY_INIT_GUESS_TRAJ and (cfg.USE_GEOM_INIT_GUESS or cfg.USE_CROC_INIT
 
 if cfg.LOAD_CS_COM :
     cs_com = ContactSequenceHumanoid(0)
-    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM.xml"
-    cs_com.loadFromXML(filename, "ContactSequence")     
+    filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM"
+    cs_com.loadFromBinary(filename)     
 else:
     import mlp.centroidal.topt as centroidal
     cs_com,tp = centroidal.generateCentroidalTrajectory(cs,cs_initGuess,v)
@@ -57,7 +57,7 @@ else:
 if cfg.SAVE_CS_COM and not cfg.LOAD_CS_COM:
     filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM.xml"
     print "Write contact sequence with centroidal trajectory XML file : ",filename
-    cs_com.saveAsXML(filename, "ContactSequence") 
+    cs_com.saveAsBinary(filename) 
 if cfg.DISPLAY_COM_TRAJ:
     colors = [v.color.blue, v.color.green]
     display_tools.displayCOMTrajectory(cs_com,v,colors)

--- a/scripts/run_mlp.py
+++ b/scripts/run_mlp.py
@@ -87,8 +87,9 @@ else :
 
 if cfg.PLOT:
     from mlp.utils import plot
-    plot.plotALLFromWB(cs_com,res,cfg.DISPLAY_PLOT,cfg.SAVE_PLOT)
-
+    plot.plotALLFromWB(cs_com,res,cfg.DISPLAY_PLOT,cfg.SAVE_PLOT,cfg.OUTPUT_DIR+"/plot/"+cfg.DEMO_NAME)
+    plot.plotKneeTorque(res.t_t,res.phases_intervals,res.tau_t,6 + (res.nq - res.nv),cfg.Robot.kneeIds)
+    
 if cfg.EXPORT_OPENHRP and motion_valid:
     from mlp.export import openHRP
     openHRP.export(cs_com,res)

--- a/scripts/run_mlp.py
+++ b/scripts/run_mlp.py
@@ -5,6 +5,11 @@ print "### MLP : contact sequence ###"
 from mlp.contact_sequence import generateContactSequence
 cs,fullBody,viewer = generateContactSequence()
 
+if cfg.WRITE_STATUS:
+    f = open(cfg.STATUS_FILENAME,"a")
+    f.write("gen_cs_success: True\n")
+    f.close()
+       
 if cfg.DISPLAY_CS:
     raw_input("Press Enter to display the contact sequence ...")
     display_tools.displayContactSequence(viewer,cs,step)    
@@ -30,6 +35,11 @@ print "### MLP : centroidal  ###"
 from mlp.centroidal import generateCentroidalTrajectory
 cs_com = generateCentroidalTrajectory(cs,cs_initGuess,fullBody,viewer)
 
+if cfg.WRITE_STATUS:
+    f = open(cfg.STATUS_FILENAME,"a")
+    f.write("centroidal_success: True\n")
+    f.close()
+
 if cfg.SAVE_CS_COM:
     filename = cfg.CONTACT_SEQUENCE_PATH + "/"+cfg.DEMO_NAME+"_COM.cs"
     print "Write contact sequence binary file with centroidal trajectory : ",filename
@@ -43,6 +53,16 @@ print "### MLP : whole-body  ###"
 from mlp.wholebody import generateWholeBodyMotion
 res,robot = generateWholeBodyMotion(cs_com,fullBody,viewer)
 
+if cfg.WRITE_STATUS:
+    f = open(cfg.STATUS_FILENAME,"a")
+    f.write("wholebody_success: True\n")
+    if res.N == (int(round(cs_com.contact_phases[-1].time_trajectory[-1]/cfg.IK_dt)) + 1):
+        f.write("wholebody_reach_goal: True\n")
+    else : 
+        f.write("wholebody_reach_goal: False\n")   
+    f.close()
+
+
 if cfg.CHECK_FINAL_MOTION :
     from mlp.utils import check_path
     print "## Begin validation of the final motion (collision and joint-limits)"
@@ -51,6 +71,10 @@ if cfg.CHECK_FINAL_MOTION :
     print "## Check final motion, valid = ",motion_valid
     if not motion_valid:
         print "## First invalid time : ",t_invalid
+    if cfg.WRITE_STATUS:
+        f = open(cfg.STATUS_FILENAME,"a")
+        f.write("motion_valid: "+str(motion_valid)+"\n")
+        f.close() 
 else :
     motion_valid = True
 if cfg.DISPLAY_WB_MOTION:


### PR DESCRIPTION
Working version 0.3

# Major changes : 
* Change the way the methods to solve each subproblem are selected. Everything is completely modular now. 
* It not required anymore to run a rbprm script before running mlp. 
* Add end-effector method to compute optimized bezier from limb-rrt path
* A 'status' file can be wrote if the setting is checked
* Add three new trajectory class : HPPEffectorTrajectory, cubicSplineTrajectory, quinticSplineTrajectory
* RBPRM export to contactSequence now store the extraDOF values in reference_configuration

# Other changes : 

* plot is now independent from config
* add Plot for angular momentum and it's time derivative
* Result.tau_t is now of size nu, defined as optional parameter (default is nv-6)
* Correctly compute L and dL and acom from the wholebody motion
* Remove 'tracking error' data from Result
* For timeopt : fix the connection to the goal state with quinticSpline (instead of straight line)
* Contact sequence are stored as binary file instead of XML
