### PR TITLE
Fix TSID wrapper

### DIFF
--- a/python/mlp/utils/cs_tools.py
+++ b/python/mlp/utils/cs_tools.py
@@ -582,21 +582,26 @@ def deletePhaseWBtrajectories(phase):
     phase.ddq_t = None
     phase.tau_t = None
 
-def updateContactPlacement(cs, pid_begin, eeName, placement):
+def updateContactPlacement(cs, pid_begin, eeName, placement, update_rotation):
     """
     Starting from cs.contactPhases[pid_begin] and going until eeName is in contact,
     the placement of eeName is modified with the given placement.
     Note that the wholebody configurations are not updated !
-    :param cs:
-    :param pid_begin:
-    :param eeName:
-    :param placement:
-    :return:
+    :param cs: The ContactSequence to modify
+    :param pid_begin: the Id of the first phase to modify
+    :param eeName: the effector name
+    :param placement: the new placement for eeName
+    :param update_rotation: if True, update the placement, if False update only the translation
     """
     for pid in range(pid_begin, cs.size()):
         phase = cs.contactPhases[pid]
         if phase.isEffectorInContact(eeName):
-            phase.contactPatch(eeName).placement = placement
+            if update_rotation:
+                phase.contactPatch(eeName).placement = placement
+            else:
+                new_placement = phase.contactPatch(eeName).placement
+                new_placement.translation = placement.translation
+                phase.contactPatch(eeName).placement = new_placement
         else:
             return
 

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -614,7 +614,7 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
                 # solve HQP for the current time
                 HQPData = invdyn.computeProblemData(t, q, v)
                 if t < phase.timeInitial + dt:
-                    logger.info("final data for phase ", pid)
+                    logger.info("final data for phase %d", pid)
                     if logger.isEnabledFor(logging.INFO):
                         HQPData.print_all()
                 sol = solver.solve(HQPData)

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -539,6 +539,10 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
             if phase_prev and phase_ref.isEffectorInContact(eeName) and not phase_prev.isEffectorInContact(eeName):
                 invdyn.removeTask(dic_effectors_tasks[eeName].name, 0.0)  # remove pin task for this contact
                 logger.info("remove se3 effector task : %s", dic_effectors_tasks[eeName].name)
+                if logger.isEnabledFor(logging.DEBUG):
+                    current_placement = getCurrentEffectorPosition(robot, invdyn.data(), eeName)
+                    logger.debug("Current   effector placement : %s", current_placement)
+                    logger.debug("Reference effector placement : %s", cs.contactPhases[pid].contactPatch(eeName).placement)
                 updateContactPlacement(cs, pid, eeName,
                                        getCurrentEffectorPosition(robot, invdyn.data(), eeName),
                                        cfg.Robot.cType == "_6_DOF")
@@ -569,7 +573,7 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
                 simulator.q = q
                 simulator.v = v
             iter_for_phase += 1
-            logger.info("Start computation for phase %d , try number :  %d", pid, iter_for_phase)
+            logger.info("Start computation for phase %d , t = %f, try number :  %d", pid, t, iter_for_phase)
             # loop to generate states (q,v,a) for the current contact phase :
             while t < phase.timeFinal - (dt / 2.):
 
@@ -615,6 +619,8 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
                     logger.debug("effector %s, pos = %s", eeName, sampleEff.pos())
                     logger.debug("effector %s, vel = %s", eeName, sampleEff.vel())
 
+                logger.debug("previous q = %s", q)
+                logger.debug("previous v = %s", v)
                 # solve HQP for the current time
                 HQPData = invdyn.computeProblemData(t, q, v)
                 if t < phase.timeInitial + dt:

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -532,7 +532,8 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
                 transition_time = phase.duration + dt/2.
                 logger.info("\nTime %.3f Start breaking contact %s. transition time : %.3f\n",
                             t, contact.name, transition_time)
-                invdyn.removeRigidContact(contact.name, transition_time)
+                exist = invdyn.removeRigidContact(contact.name, transition_time)
+                assert exist, "Try to remove a non existing contact !"
 
         # add newly created contacts :
         for eeName in usedEffectors:

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -418,7 +418,9 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
     dic_contacts = {}
     for eeName in cs.contactPhases[0].effectorsInContact():
         # replace the initial contact patch placements if needed to match exactly the current position in the problem:
-        updateContactPlacement(cs, 0, eeName, getCurrentEffectorPosition(robot, invdyn.data(), eeName))
+        updateContactPlacement(cs, 0, eeName,
+                               getCurrentEffectorPosition(robot, invdyn.data(), eeName),
+                               cfg.Robot.cType == "_6_DOF")
         # create the contacts :
         contact = createContactForEffector(cfg, invdyn, robot, eeName, phase0.contactPatch(eeName))
         dic_contacts.update({eeName: contact})
@@ -537,7 +539,9 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
             if phase_prev and phase_ref.isEffectorInContact(eeName) and not phase_prev.isEffectorInContact(eeName):
                 invdyn.removeTask(dic_effectors_tasks[eeName].name, 0.0)  # remove pin task for this contact
                 logger.info("remove se3 effector task : %s", dic_effectors_tasks[eeName].name)
-                updateContactPlacement(cs, pid, eeName, getCurrentEffectorPosition(robot, invdyn.data(), eeName))
+                updateContactPlacement(cs, pid, eeName,
+                                       getCurrentEffectorPosition(robot, invdyn.data(), eeName),
+                                       cfg.Robot.cType == "_6_DOF")
                 contact = createContactForEffector(cfg, invdyn, robot, eeName, phase.contactPatch(eeName))
                 dic_contacts.update({eeName: contact})
                 logger.info("Create contact for : %s", eeName)

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -524,17 +524,6 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
                 adjustEndEffectorTrajectoryIfNeeded(cfg, phase_ref, robot, invdyn.data(), eeName, effectorMethod)
                 logger.info("t interval : %s", time_interval)
 
-
-        # start removing the contact that will be broken in the next phase :
-        # (This tell the solver that it should start minimizing the contact force on this contact, and ideally get to 0 at the given time)
-        for eeName, contact in dic_contacts.items():
-            if phase_next and phase.isEffectorInContact(eeName) and not phase_next.isEffectorInContact(eeName):
-                transition_time = phase.duration + dt/2.
-                logger.info("\nTime %.3f Start breaking contact %s. transition time : %.3f\n",
-                            t, contact.name, transition_time)
-                exist = invdyn.removeRigidContact(contact.name, transition_time)
-                assert exist, "Try to remove a non existing contact !"
-
         # add newly created contacts :
         for eeName in usedEffectors:
             if phase_prev and phase_ref.isEffectorInContact(eeName) and not phase_prev.isEffectorInContact(eeName):
@@ -550,6 +539,16 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
                 contact = createContactForEffector(cfg, invdyn, robot, eeName, phase.contactPatch(eeName))
                 dic_contacts.update({eeName: contact})
                 logger.info("Create contact for : %s", eeName)
+
+        # start removing the contact that will be broken in the next phase :
+        # (This tell the solver that it should start minimizing the contact force on this contact, and ideally get to 0 at the given time)
+        for eeName, contact in dic_contacts.items():
+            if phase_next and phase.isEffectorInContact(eeName) and not phase_next.isEffectorInContact(eeName):
+                transition_time = phase.duration + dt/2.
+                logger.info("\nTime %.3f Start breaking contact %s. transition time : %.3f\n",
+                            t, contact.name, transition_time)
+                exist = invdyn.removeRigidContact(contact.name, transition_time)
+                assert exist, "Try to remove a non existing contact !"
 
         if cfg.WB_STOP_AT_EACH_PHASE:
             input('start simulation')


### PR DESCRIPTION
Fix three issues:

* Error when not using AM task and using DEBUG logging level
* Contact points normal were taken from the frame orientation instead of from the reference contact
* Fix a crash in TSID when three adjacents phases created -> broke -> created the same contact