### PR TITLE
Update to changes in multicontact-api

### DIFF
--- a/python/mlp/__main__.py
+++ b/python/mlp/__main__.py
@@ -4,6 +4,7 @@ import atexit
 import argparse
 import os
 from mlp import LocoPlanner, Config
+from hpp.corbaserver.rbprm.utils import ServerManager
 
 
 # init argument parser
@@ -18,35 +19,14 @@ demo_name = args.demo_name
 cfg = Config()
 cfg.load_scenario_config(demo_name)
 
-
-# kill already existing instance of the server
-subprocess.run(["killall", "hpp-rbprm-server"])
-# run the server in background :
-# stdout and stderr outputs of the child process are redirected to devnull (hidden).
-# preexec_fn is used to ignore ctrl-c signal send to the main script (otherwise they are forwarded to the child process)
-process_server = subprocess.Popen("hpp-rbprm-server",
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.DEVNULL,
-                                  preexec_fn=os.setpgrp)
-# register cleanup methods to kill server when exiting python interpreter
-atexit.register(process_server.kill)
-
-# do the same for the viewer, exept if --no-viewer flag is set
-if not args.no_viewer:
-    subprocess.run(["killall", "gepetto-gui"])
-    process_viewer = subprocess.Popen("gepetto-gui",
-                                      stdout=subprocess.PIPE,
-                                      stderr=subprocess.DEVNULL,
-                                      preexec_fn=os.setpgrp)
-    atexit.register(process_viewer.kill)
-
-
-# wait a little for the initialization of the server/viewer
-time.sleep(3)
-
-
-loco_planner = LocoPlanner(cfg)
-loco_planner.run()
+with ServerManager('hpp-rbprm-server'):
+    if not args.no_viewer:
+        with ServerManager('gepetto-gui'):
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
+    else:
+        loco_planner = LocoPlanner(cfg)
+        loco_planner.run()
 
 
 

--- a/python/mlp/config.py
+++ b/python/mlp/config.py
@@ -231,7 +231,8 @@ class Config:
             self.IK_store_joints_derivatives = False
             self.IK_store_joints_torque = False
             self.SAVE_CS_WB = False
-
+        if self.ITER_DYNAMIC_FILTER > 0:
+            self.IK_store_centroidal = True
 
 
     def get_contact_generation_method(self):

--- a/python/mlp/contact_sequence/manually_defined/climb_platforms.py
+++ b/python/mlp/contact_sequence/manually_defined/climb_platforms.py
@@ -1,0 +1,97 @@
+from mlp.utils.cs_tools import addPhaseFromConfig, createPhaseFromConfig
+import multicontact_api
+from multicontact_api import ContactSequence
+import mlp.viewer.display_tools as display_tools
+from pinocchio import SE3
+from numpy import array
+from mlp.utils.cs_tools import walk
+from talos_rbprm.talos import Robot  # change robot here
+multicontact_api.switchToNumpyArray()
+
+ENV_NAME = "multicontact/plateforme_surfaces_noscale"
+
+fb, v = display_tools.initScene(Robot, ENV_NAME, False)
+gui = v.client.gui
+sceneName = v.sceneName
+cs = ContactSequence(0)
+
+cs_platforms = ContactSequence(0)
+cs_platforms.loadFromBinary("talos_plateformes.cs")
+p0_platform = cs_platforms.contactPhases[0]
+
+q = [   0.0,
+        0.0,
+        1.02127,
+        0.0,
+        0.0,
+        0.0,
+        1.,  # Free flyer
+        0.0,
+        0.0,
+        -0.411354,
+        0.859395,
+        -0.448041,
+        -0.001708,  # Left Leg
+        0.0,
+        0.0,
+        -0.411354,
+        0.859395,
+        -0.448041,
+        -0.001708,  # Right Leg
+        0.0,
+        0.006761,  # Chest
+        0.40,
+        0.24,
+        -0.6,
+        -1.45,
+        0.0,
+        -0.0,
+        0.,
+        -0.005,  # Left Arm
+        -0.4,
+        -0.24,
+        0.6,
+        -1.45,
+        0.0,
+        0.0,
+        0.,
+        -0.005,  # Right Arm
+        0.,
+        0.
+    ] + [0]*6
+
+q[:2] = [-0.15, 0.25]
+addPhaseFromConfig(fb, cs, q, [fb.rLegId, fb.lLegId])
+q[:3] = [0.11, 0.25, 1.18127]
+p_up = createPhaseFromConfig(fb, q, [fb.rLegId, fb.lLegId])
+
+#make the first step to the platform
+cs.moveEffectorToPlacement(fb.rfoot,p_up.contactPatch(fb.rfoot).placement)
+cs.moveEffectorToPlacement(fb.lfoot,p_up.contactPatch(fb.lfoot).placement)
+# Make the second step to connect the cs_plateform
+cs.moveEffectorToPlacement(fb.rfoot,p0_platform.contactPatch(fb.rfoot).placement)
+cs.moveEffectorToPlacement(fb.lfoot,p0_platform.contactPatch(fb.lfoot).placement)
+
+# copy the cs_plateform
+
+for phase in cs_platforms.contactPhases[1:]:
+    cs.append(phase)
+
+
+## Add final step :
+q[0] = 1.14
+p_end = createPhaseFromConfig(fb, q, [fb.rLegId, fb.lLegId])
+q[:3] = [1.37, 0.25, 1.02127]
+p_floor = createPhaseFromConfig(fb, q, [fb.rLegId, fb.lLegId])
+
+#make a step to got to the edge of the platform
+cs.moveEffectorToPlacement(fb.rfoot,p_end.contactPatch(fb.rfoot).placement)
+cs.moveEffectorToPlacement(fb.lfoot,p_end.contactPatch(fb.lfoot).placement)
+#make the last step on the floor
+cs.moveEffectorToPlacement(fb.rfoot,p_floor.contactPatch(fb.rfoot).placement)
+cs.moveEffectorToPlacement(fb.lfoot,p_floor.contactPatch(fb.lfoot).placement)
+
+display_tools.displaySteppingStones(cs, gui, sceneName, fb)
+filename = "talos_platformes_full.cs"
+print("Write contact sequence binary file : ", filename)
+cs.saveAsBinary(filename)

--- a/python/mlp/contact_sequence/manually_defined/step_in_place.py
+++ b/python/mlp/contact_sequence/manually_defined/step_in_place.py
@@ -45,4 +45,4 @@ setFinalState(cs,com, q_ref)
 
 assert cs.haveConsistentContacts()
 
-cs.saveAsBinary("talos_flatGround.cs")
+cs.saveAsBinary("step_in_place.cs")

--- a/python/mlp/contact_sequence/manually_defined/step_in_place_quasiStatic.py
+++ b/python/mlp/contact_sequence/manually_defined/step_in_place_quasiStatic.py
@@ -63,7 +63,7 @@ cs.contactPhases[-2].c_final = c_r
 cs.contactPhases[-1].c_init = c_r
 setFinalState(cs,com, q_ref)
 
-cs.saveAsBinary("talos_flatGround.cs")
+cs.saveAsBinary("step_in_place_quasistatic.cs")
 
 t = 0
 for pid, phase in enumerate(cs.contactPhases):
@@ -99,4 +99,4 @@ assert cs.haveConsistentContacts()
 assert cs.haveCentroidalValues()
 assert cs.haveCentroidalTrajectories()
 
-cs.saveAsBinary("talos_flatGround_COM.cs")
+cs.saveAsBinary("step_in_place_quasistatic_COM.cs")

--- a/python/mlp/demo_configs/common_anymal.py
+++ b/python/mlp/demo_configs/common_anymal.py
@@ -26,6 +26,7 @@ level_am = 1
 YAW_ROT_GAIN = 1.
 
 IK_eff_size = Robot.dict_size.copy()
+PLOT_CIRCLE_RADIUS = 0.01 # radius of the circle used to display the contacts
 
 # phases duration
 DURATION_INIT = 1.  # Time to init the motion

--- a/python/mlp/utils/requirements.py
+++ b/python/mlp/utils/requirements.py
@@ -12,6 +12,7 @@ class Requirements():
     timings = False
     consistentContacts = False
     friction = False
+    contactModel = False
     rootTrajectories = False
     COMvalues = False
     AMvalues = False
@@ -60,6 +61,18 @@ class Requirements():
                 print("An error occurred in setAllUninitializedFrictionCoef.")
                 return False
         return True
+
+    @classmethod
+    def requireContactModel(cls, cs, Robot):
+        if not cs.haveContactModelDefined():
+            print("- Contact sequence do not have ContactModel defined.")
+            print("Set all the uninitialized model from the Robot class")
+            cs_tools.setAllUninitializedContactModel(cs, Robot)
+            if not cs.haveContactModelDefined():
+                print("An error occurred in setAllUninitializedContactModel.")
+                return False
+        return True
+
 
     @classmethod
     def requireRootTrajectories(cls, cs, cfg):
@@ -196,6 +209,8 @@ class Requirements():
             print("- Consistent contacts")
         if cls.friction:
             print("- friction coefficient for all contacts")
+        if cls.contactModel:
+            print("- ContactModel defined for all ContactPhases")
         if cls.COMvalues:
             print("- c_init / final for each phases")
         if cls.AMvalues:
@@ -232,6 +247,8 @@ class Requirements():
             assert cs.haveConsistentContacts(), "Contact sequence do not have consistent contacts."
         if cls.friction:
             assert cs.haveFriction(), "Contact sequence do not have friction coefficient defined for all contacts."
+        if cls.contactModel:
+            assert cs.haveContactModelDefined(), "Contact Sequence do not have ContactModel defined for all phases."
         if cls.rootTrajectories:
             assert cs.haveRootTrajectories(), "Contact sequence do not have consistent Root trajectories."
         if cls.COMvalues:
@@ -303,6 +320,9 @@ class Requirements():
                 return False
         if cls.friction:
             if not cls.requireFriction(cs, cfg.MU):
+                return False
+        if cls.contactModel:
+            if not cls.requireContactModel(cs, cfg.Robot):
                 return False
         if cls.rootTrajectories:
             if not cls.requireRootTrajectories(cs, cfg):

--- a/python/mlp/utils/util.py
+++ b/python/mlp/utils/util.py
@@ -522,3 +522,22 @@ def constantSE3curve(placement, t_min, t_max = None):
     rot = SO3Linear(placement.rotation, placement.rotation, t_min, t_max)
     trans = polynomial(placement.translation.reshape(-1,1), t_min, t_max)
     return SE3Curve(trans, rot)
+
+
+def buildRectangularContactPoints(size, transform):
+    """
+    Build Array at the corners of the feet
+    :param size: list of len 2 : size of the rectangle along x and y
+    :param transform: an SE3 object: transform applied to all vectors
+    :return: a 3x4 Array, with the 3D position of one contact point per columns
+    """
+    lxp = size[0] / 2. + transform.translation[0]  # foot length in positive x direction
+    lxn = size[0] / 2. - transform.translation[0]  # foot length in negative x direction
+    lyp = size[1] / 2. + transform.translation[1]  # foot length in positive y direction
+    lyn = size[1] / 2. - transform.translation[1]  # foot length in negative y direction
+    lz = transform.translation[2]  # foot sole height with respect to ankle joint
+    contact_Point = np.ones((3, 4))
+    contact_Point[0, :] = [-lxn, -lxn, lxp, lxp]
+    contact_Point[1, :] = [-lyn, lyp, -lyn, lyp]
+    contact_Point[2, :] = [lz] * 4
+    return contact_Point

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -12,7 +12,7 @@ from numpy.linalg import norm as norm
 import os
 from rospkg import RosPack
 import time
-from multicontact_api import ContactPhase, ContactSequence
+from multicontact_api import ContactPhase, ContactSequence, ContactType
 from curves import piecewise, piecewise_SE3, polynomial
 from mlp.utils.computation_tools import shiftZMPtoFloorAltitude
 import mlp.viewer.display_tools as display_tools
@@ -33,6 +33,7 @@ eigenpy.switchToNumpyArray()
 class WholebodyInputsTsid(Requirements):
     consistentContacts = True
     friction = True
+    contactModel = True
     timings = True
     centroidalTrajectories = True
     effectorTrajectories = True
@@ -42,20 +43,6 @@ class WholebodyOutputsTsid(Requirements):
     consistentContacts = True
     timings = True
     jointsTrajectories = True
-
-
-def buildRectangularContactPoints(size, transform):
-    # build matrices with corners of the feet
-    lxp = size[0] / 2. + transform.translation[0]  # foot length in positive x direction
-    lxn = size[0] / 2. - transform.translation[0]  # foot length in negative x direction
-    lyp = size[1] / 2. + transform.translation[1]  # foot length in positive y direction
-    lyn = size[1] / 2. - transform.translation[1]  # foot length in negative y direction
-    lz = transform.translation[2]  # foot sole height with respect to ankle joint
-    contact_Point = np.ones((3, 4))
-    contact_Point[0, :] = [-lxn, -lxn, lxp, lxp]
-    contact_Point[1, :] = [-lyn, lyp, -lyn, lyp]
-    contact_Point[2, :] = [lz] * 4
-    return contact_Point
 
 
 def getCurrentEffectorPosition(robot, data, eeName):
@@ -99,18 +86,20 @@ def createContactForEffector(cfg, invdyn, robot, eeName, patch):
     logger.info("create contact for effector %s", eeName)
     logger.info("contact placement : %s", patch.placement)
     logger.info("contact_normal : %s", contactNormal)
-    if cfg.Robot.cType == "_3_DOF":
+    if patch.contact_model.contact_type == ContactType.CONTACT_POINT:
         contact = tsid.ContactPoint("contact_" + eeName, robot, eeName, contactNormal, patch.friction, cfg.fMin, cfg.fMax)
         mask = np.ones(3)
         contact.useLocalFrame(False)
         logger.info("create contact point")
-    else:
-        contact_Points = buildRectangularContactPoints(cfg.IK_eff_size[eeName],cfg.Robot.dict_offset[eeName] )
-        contact = tsid.Contact6d("contact_" + eeName, robot, eeName, contact_Points, contactNormal, patch.friction, cfg.fMin,
+    elif patch.contact_model.contact_type == ContactType.CONTACT_PLANAR:
+        contact_points = patch.contact_model.contact_points_positions
+        contact = tsid.Contact6d("contact_" + eeName, robot, eeName, contact_points, contactNormal, patch.friction, cfg.fMin,
                                  cfg.fMax)
         mask = np.ones(6)
         logger.info("create rectangular contact")
-        logger.info("contact points : \n %s", contact_Points)
+        logger.info("contact points : \n %s", contact_points)
+    else:
+        raise RuntimeError("Unknown contact type : ", patch.contact_model.contact_type)
     contact.setKp(cfg.kp_contact * mask)
     contact.setKd(2.0 * np.sqrt(cfg.kp_contact) * mask)
     contact.setReference(patch.placement)

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -702,7 +702,7 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None):
     # end for all phases
     # store the data of the last point
     phase_prev = phase
-    phase = ContactPhase()
+    phase = ContactPhase(phase_prev)
     storeData(True)
     setPreviousFinalValues(phase_prev, phase, cfg)
     time_end = time.time() - time_start

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -171,7 +171,7 @@ def adjustEndEffectorTrajectoryIfNeeded(cfg, phase, robot, data, eeName, effecto
     """
     current_placement = getCurrentEffectorPosition(robot, data, eeName)
     ref_placement = phase.effectorTrajectory(eeName).evaluateAsSE3(phase.timeInitial)
-    if not current_placement.isApprox(ref_placement, 1e-3):
+    if not current_placement.isApprox(ref_placement, 1e-2):
         logger.warning("- End effector trajectory need to be adjusted.")
         placement_end = phase.effectorTrajectory(eeName).evaluateAsSE3(phase.timeFinal)
         ref_traj = effectorMethod(cfg, [phase.timeInitial, phase.timeFinal], current_placement, placement_end, 0)

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -6,6 +6,7 @@ SET(${PROJECT_NAME}_PYTHON_TESTS
   test_talos_walk_sl1m_topt
   test_talos_stairs_manual_limb_rrt
   test_talos_stairs_sl1m_mopt
+  generate_examples
   )
 
 FOREACH(TEST ${${PROJECT_NAME}_PYTHON_TESTS})

--- a/tests/python/generate_examples.py
+++ b/tests/python/generate_examples.py
@@ -1,0 +1,101 @@
+from mlp import LocoPlanner, Config
+from hpp.corbaserver.rbprm.utils import ServerManager
+import time, subprocess, shutil
+
+def store_all(cfg):
+    cfg.IK_store_centroidal = True
+    cfg.IK_store_zmp = True
+    cfg.IK_store_effector = True
+    cfg.IK_store_contact_forces = True
+    cfg.IK_store_joints_derivatives = True
+    cfg.IK_store_joints_torque = True
+
+def set_cs_names(cfg, demo_name):
+    cfg.CS_FILENAME = demo_name + ".cs"
+    cfg.COM_FILENAME = demo_name + "_COM.cs"
+    cfg.REF_FILENAME = demo_name + "_REF.cs"
+    cfg.WB_FILENAME = demo_name + "_WB.cs"
+
+def gen_com_motion():
+    import mlp.contact_sequence.manually_defined.com_motion_above_feet
+    cfg = Config()
+    cfg.load_scenario_config("talos_flatGround")
+    cfg.centroidal_method="load"
+    demo_name = "com_motion_above_feet"
+    set_cs_names(cfg, demo_name)
+    store_all(cfg)
+
+    loco_planner = LocoPlanner(cfg)
+    loco_planner.run()
+
+def gen_step_in_place_quasistatic():
+    import mlp.contact_sequence.manually_defined.step_in_place_quasiStatic
+    cfg = Config()
+    cfg.load_scenario_config("talos_flatGround_quasiStatic")
+    cfg.centroidal_method="load"
+    demo_name = "step_in_place_quasistatic"
+    set_cs_names(cfg, demo_name)
+    store_all(cfg)
+
+    loco_planner = LocoPlanner(cfg)
+    loco_planner.run()
+
+def gen_step_in_place():
+    import mlp.contact_sequence.manually_defined.step_in_place
+    cfg = Config()
+    cfg.load_scenario_config("talos_flatGround")
+    cfg.contact_generation_method = "load"
+    cfg.centroidal_method="momentumopt"
+    cfg.ITER_DYNAMIC_FILTER = 0
+    demo_name = "step_in_place"
+    set_cs_names(cfg, demo_name)
+    store_all(cfg)
+
+    loco_planner = LocoPlanner(cfg)
+    loco_planner.run()
+
+
+def gen_walk_20cm_cs():
+    import mlp.contact_sequence.manually_defined.walk_1m
+    shutil.move("talos_flatGround.cs", "walk_20cm.cs")
+    shutil.copy("walk_20cm.cs", "walk_20cm_quasistatic.cs")
+
+
+def gen_walk_20cm():
+    cfg = Config()
+    cfg.load_scenario_config("talos_flatGround")
+    cfg.contact_generation_method = "load"
+    cfg.centroidal_method = "momentumopt"
+    cfg.ITER_DYNAMIC_FILTER = 2
+    demo_name = "walk_20cm"
+    set_cs_names(cfg, demo_name)
+    store_all(cfg)
+
+    loco_planner = LocoPlanner(cfg)
+    loco_planner.run()
+
+def gen_walk_20cm_quasistatic():
+    cfg = Config()
+    cfg.load_scenario_config("talos_flatGround_quasiStatic")
+    cfg.contact_generation_method = "load"
+    cfg.centroidal_method = "quasistatic"
+    cfg.ITER_DYNAMIC_FILTER = 0
+    demo_name = "walk_20cm_quasistatic"
+    set_cs_names(cfg, demo_name)
+    store_all(cfg)
+
+    loco_planner = LocoPlanner(cfg)
+    loco_planner.run()
+
+
+if __name__ == "__main__":
+    with ServerManager('hpp-rbprm-server'):
+        gen_com_motion()
+        gen_step_in_place_quasistatic()
+        gen_step_in_place()
+        gen_walk_20cm_cs()
+        gen_walk_20cm()
+        gen_walk_20cm_quasistatic()
+
+
+

--- a/tests/python/test_talos_stairs_manual_limb_rrt.py
+++ b/tests/python/test_talos_stairs_manual_limb_rrt.py
@@ -12,6 +12,7 @@ from numpy import array
 import multicontact_api
 from multicontact_api import ContactSequence
 import mlp.viewer.display_tools as display_tools
+from hpp.corbaserver.rbprm.utils import ServerManager
 from talos_rbprm.talos import Robot  # change robot here
 
 def create_stairs_cs():
@@ -42,10 +43,6 @@ def create_stairs_cs():
 
 class TestTalosStairsManualLimbRRT(unittest.TestCase):
     def test_talos_stairs_manual_limb_rrt(self):
-        subprocess.run(["killall", "hpp-rbprm-server"])
-        process = subprocess.Popen("hpp-rbprm-server")
-        time.sleep(3)
-
         cfg = Config()
         cfg.load_scenario_config("talos_stairs10")
         cfg.contact_generation_method = "load"
@@ -57,21 +54,20 @@ class TestTalosStairsManualLimbRRT(unittest.TestCase):
         cfg.IK_store_joints_derivatives = True
         cfg.IK_store_joints_torque = True
         cfg.ITER_DYNAMIC_FILTER = 0
-        cs = create_stairs_cs()
-        if not os.path.exists(cfg.CONTACT_SEQUENCE_PATH):
-            os.makedirs(cfg.CONTACT_SEQUENCE_PATH)
-        filename = cfg.CS_FILENAME
-        print("Write contact sequence binary file : ", filename)
-        cs.saveAsBinary(filename)
+
+        with ServerManager('hpp-rbprm-server'):
+            cs = create_stairs_cs()
+            if not os.path.exists(cfg.CONTACT_SEQUENCE_PATH):
+                os.makedirs(cfg.CONTACT_SEQUENCE_PATH)
+            filename = cfg.CS_FILENAME
+            print("Write contact sequence binary file : ", filename)
+            cs.saveAsBinary(filename)
 
 
-        loco_planner = LocoPlanner(cfg)
-        loco_planner.run()
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
 
-        check_motion(self, loco_planner)
-
-        process.kill()
-
+            check_motion(self, loco_planner)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_talos_stairs_sl1m_mopt.py
+++ b/tests/python/test_talos_stairs_sl1m_mopt.py
@@ -3,14 +3,11 @@
 import unittest
 import subprocess
 import time
+from hpp.corbaserver.rbprm.utils import ServerManager
 from mlp import LocoPlanner, Config
 
 class TestTalosStairsSl1mMopt(unittest.TestCase):
     def test_talos_stairs_sl1m_mopt(self):
-        subprocess.run(["killall", "hpp-rbprm-server"])
-        process = subprocess.Popen("hpp-rbprm-server")
-        time.sleep(3)
-
         cfg = Config()
         cfg.IK_store_centroidal = True
         cfg.IK_store_zmp = True
@@ -24,26 +21,24 @@ class TestTalosStairsSl1mMopt(unittest.TestCase):
         cfg.wholebody_method="none"
         cfg.ITER_DYNAMIC_FILTER = 0
 
-        loco_planner = LocoPlanner(cfg)
-        loco_planner.run()
+        with ServerManager('hpp-rbprm-server'):
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
 
-        self.assertTrue(loco_planner.cs.size() > 2)
-        self.assertTrue(loco_planner.cs.size() < 50)
-        self.assertEqual(loco_planner.cs.size(), loco_planner.cs_com.size())
-        self.assertEqual(loco_planner.cs.size(), loco_planner.cs_ref.size())
-        self.assertIsNone(loco_planner.cs_wb)
+            self.assertTrue(loco_planner.cs.size() > 2)
+            self.assertTrue(loco_planner.cs.size() < 50)
+            self.assertEqual(loco_planner.cs.size(), loco_planner.cs_com.size())
+            self.assertEqual(loco_planner.cs.size(), loco_planner.cs_ref.size())
+            self.assertIsNone(loco_planner.cs_wb)
 
-        # check that the sequence contains the expected data:
-        self.assertTrue(loco_planner.cs.haveConsistentContacts())
+            # check that the sequence contains the expected data:
+            self.assertTrue(loco_planner.cs.haveConsistentContacts())
 
-        self.assertTrue(loco_planner.cs_ref.haveConsistentContacts())
-        self.assertTrue(loco_planner.cs_ref.haveTimings())
-        self.assertTrue(loco_planner.cs_ref.haveCentroidalTrajectories())
-        self.assertTrue(loco_planner.cs_ref.haveZMPtrajectories())
-        self.assertTrue(loco_planner.cs_ref.haveEffectorsTrajectories(1e-2))
-
-        process.kill()
-
+            self.assertTrue(loco_planner.cs_ref.haveConsistentContacts())
+            self.assertTrue(loco_planner.cs_ref.haveTimings())
+            self.assertTrue(loco_planner.cs_ref.haveCentroidalTrajectories())
+            self.assertTrue(loco_planner.cs_ref.haveZMPtrajectories())
+            self.assertTrue(loco_planner.cs_ref.haveEffectorsTrajectories(1e-2))
 
 
 if __name__ == '__main__':

--- a/tests/python/test_talos_walk_rbprm_mopt.py
+++ b/tests/python/test_talos_walk_rbprm_mopt.py
@@ -5,13 +5,10 @@ import subprocess
 import time
 from mlp import LocoPlanner, Config
 from utils import check_motion
+from hpp.corbaserver.rbprm.utils import ServerManager
 
 class TestTalosWalkRbprmMopt(unittest.TestCase):
     def test_talos_walk_rbprm_mopt(self):
-        subprocess.run(["killall", "hpp-rbprm-server"])
-        process = subprocess.Popen("hpp-rbprm-server")
-        time.sleep(3)
-
         cfg = Config()
         cfg.load_scenario_config("talos_flatGround")
         cfg.contact_generation_method = "rbprm"
@@ -24,13 +21,11 @@ class TestTalosWalkRbprmMopt(unittest.TestCase):
         cfg.IK_store_joints_torque = True
         cfg.ITER_DYNAMIC_FILTER = 0
 
-        loco_planner = LocoPlanner(cfg)
-        loco_planner.run()
+        with ServerManager('hpp-rbprm-server'):
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
 
-        check_motion(self, loco_planner)
-
-        process.kill()
-
+            check_motion(self, loco_planner)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_talos_walk_sl1m_mopt_dyn_filter.py
+++ b/tests/python/test_talos_walk_sl1m_mopt_dyn_filter.py
@@ -5,13 +5,10 @@ import subprocess
 import time
 from mlp import LocoPlanner, Config
 from utils import check_motion
+from hpp.corbaserver.rbprm.utils import ServerManager
 
 class TestTalosWalkSl1mMoptDynFilter(unittest.TestCase):
     def test_talos_walk_sl1m_mopt_dyn_filter(self):
-        subprocess.run(["killall", "hpp-rbprm-server"])
-        process = subprocess.Popen("hpp-rbprm-server")
-        time.sleep(3)
-
         cfg = Config()
         cfg.load_scenario_config("talos_flatGround")
         cfg.contact_generation_method = "sl1m"
@@ -24,16 +21,14 @@ class TestTalosWalkSl1mMoptDynFilter(unittest.TestCase):
         cfg.IK_store_joints_torque = True
         cfg.ITER_DYNAMIC_FILTER = 2
 
-        loco_planner = LocoPlanner(cfg)
-        loco_planner.run()
+        with ServerManager('hpp-rbprm-server'):
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
 
-        check_motion(self, loco_planner)
-        self.assertEqual(len(loco_planner.cs_com_iters), 3)
-        self.assertEqual(len(loco_planner.cs_ref_iters), 3)
-        self.assertEqual(len(loco_planner.cs_wb_iters), 3)
-
-        process.kill()
-
+            check_motion(self, loco_planner)
+            self.assertEqual(len(loco_planner.cs_com_iters), 3)
+            self.assertEqual(len(loco_planner.cs_ref_iters), 3)
+            self.assertEqual(len(loco_planner.cs_wb_iters), 3)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_talos_walk_sl1m_quasistatic.py
+++ b/tests/python/test_talos_walk_sl1m_quasistatic.py
@@ -5,13 +5,10 @@ import subprocess
 import time
 from mlp import LocoPlanner, Config
 from utils import check_motion
+from hpp.corbaserver.rbprm.utils import ServerManager
 
 class TestTalosWalkSl1mQuasistatic(unittest.TestCase):
     def test_talos_walk_sl1m_quasistatic(self):
-        subprocess.run(["killall", "hpp-rbprm-server"])
-        process = subprocess.Popen("hpp-rbprm-server")
-        time.sleep(3)
-
         cfg = Config()
         cfg.load_scenario_config("talos_flatGround_quasiStatic")
         cfg.contact_generation_method = "sl1m"
@@ -24,13 +21,11 @@ class TestTalosWalkSl1mQuasistatic(unittest.TestCase):
         cfg.IK_store_joints_torque = True
         cfg.ITER_DYNAMIC_FILTER = 0
 
-        loco_planner = LocoPlanner(cfg)
-        loco_planner.run()
+        with ServerManager('hpp-rbprm-server'):
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
 
-        check_motion(self, loco_planner)
-
-        process.kill()
-
+            check_motion(self, loco_planner)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_talos_walk_sl1m_quasistatic_no_store.py
+++ b/tests/python/test_talos_walk_sl1m_quasistatic_no_store.py
@@ -5,13 +5,10 @@ import subprocess
 import time
 from mlp import LocoPlanner, Config
 from utils import check_motion
+from hpp.corbaserver.rbprm.utils import ServerManager
 
 class TestTalosWalkSl1mQuasistaticNoStore(unittest.TestCase):
     def test_talos_walk_sl1m_quasistatic_no_store(self):
-        subprocess.run(["killall", "hpp-rbprm-server"])
-        process = subprocess.Popen("hpp-rbprm-server")
-        time.sleep(3)
-
         cfg = Config()
         cfg.load_scenario_config("talos_flatGround_quasiStatic")
         cfg.contact_generation_method = "sl1m"
@@ -24,12 +21,11 @@ class TestTalosWalkSl1mQuasistaticNoStore(unittest.TestCase):
         cfg.IK_store_joints_torque = False
         cfg.ITER_DYNAMIC_FILTER = 0
 
-        loco_planner = LocoPlanner(cfg)
-        loco_planner.run()
+        with ServerManager('hpp-rbprm-server'):
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
 
-        check_motion(self, loco_planner, False)
-
-        process.kill()
+            check_motion(self, loco_planner, False)
 
 
 

--- a/tests/python/test_talos_walk_sl1m_topt.py
+++ b/tests/python/test_talos_walk_sl1m_topt.py
@@ -5,13 +5,10 @@ import subprocess
 import time
 from mlp import LocoPlanner, Config
 from utils import check_motion
+from hpp.corbaserver.rbprm.utils import ServerManager
 
 class TestTalosWalkSl1mTopt(unittest.TestCase):
     def test_talos_walk_sl1m_topt(self):
-        subprocess.run(["killall", "hpp-rbprm-server"])
-        process = subprocess.Popen("hpp-rbprm-server")
-        time.sleep(3)
-
         cfg = Config()
         cfg.load_scenario_config("talos_flatGround")
         cfg.contact_generation_method = "sl1m"
@@ -25,15 +22,13 @@ class TestTalosWalkSl1mTopt(unittest.TestCase):
         cfg.ITER_DYNAMIC_FILTER = 0
         cfg.TIMEOPT_CONFIG_FILE="cfg_softConstraints_timeopt_talos.yaml"
 
-        loco_planner = LocoPlanner(cfg)
-        loco_planner.run()
+        with ServerManager('hpp-rbprm-server'):
+            loco_planner = LocoPlanner(cfg)
+            loco_planner.run()
 
-        check_motion(self, loco_planner)
-        self.assertNotEqual(loco_planner.cs.contactPhases[-1].timeFinal, loco_planner.cs_com.contactPhases[-1].timeFinal)
-        self.assertEqual(loco_planner.cs_com.contactPhases[-1].timeFinal, loco_planner.cs_wb.contactPhases[-1].timeFinal)
-
-        process.kill()
-
+            check_motion(self, loco_planner)
+            self.assertNotEqual(loco_planner.cs.contactPhases[-1].timeFinal, loco_planner.cs_com.contactPhases[-1].timeFinal)
+            self.assertEqual(loco_planner.cs_com.contactPhases[-1].timeFinal, loco_planner.cs_wb.contactPhases[-1].timeFinal)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Utils
* Requirement can now check if the ContactModel are correctly initialized
* Add a method to initialize the ContactModel from the Robot class

## Wholebody
* TSID: use the ContactModel stored in the sequence to define the contact points
* fix the last values stored for the end-effectors at the last iteration
* Increase the threshold before adjusting the effector trajectories

## Tests

* Use the ServerManager from rbprm
* Add a script to generate all the examples used by multicontact-api. This script doesn't test anything except that this specifics scenarios/setting can run without error. 

## Main and config

* Use the ServerManager from rbprm
* Assure that when dynamic_filter is used, `IK_STORE_CENTROIDAL = True`
* Fix anymal configuration file when plotting