### PR TITLE
Update to use MIP/quadruped version of SL1M

### DIFF
--- a/momentumopt_configs/cfg_softConstraints_solo.yaml
+++ b/momentumopt_configs/cfg_softConstraints_solo.yaml
@@ -16,15 +16,15 @@ planner_variables:
   com_displacement: [0., 0., 0.]
   num_com_viapoints: 0
   com_viapoints:
-  max_time_iterations: 10000
+  max_time_iterations: 100000
   max_time_residual_tolerance: 1e-3
-  min_time_residual_improvement: 1e-5
+  min_time_residual_improvement: 1e-6
 
   gravity: 9.81
   robot_mass: 2.5
   friction_coeff: 0.9
   friction_cone: LinearCone  # Types: LinearCone, SocCone #
-  torque_range: [-25.0, 25.0]
+  torque_range: [-10.0, 10.0]
   eff_offset_rf: [0.19, -0.15, 0]
   eff_offset_lf: [0.19, 0.15, 0]
   eff_offset_rh: [-0.19, -0.15 ,0]
@@ -42,9 +42,9 @@ planner_variables:
   w_time: 1000.0 # weight of the cost to keep the defined duration of each phases
   w_com:           [ 1000,  1000,  100]
   w_amom:          [ 0.500,  0.500,  0.500]
-  w_lmom:          [ 1.,  2.,  0.001]
+  w_lmom:          [ 1,  10.,  0.1]
   w_amomd:         [ 0.100,  0.400,  0.100]
-  w_lmomd:         [ 0.1,  0.1,  0.015]
+  w_lmomd:         [ 0.1,  1.,  0.5]
   w_amom_final:    [ 10.00,  10.00,  10.00]
   w_lmom_final:    [ 10.00,  10.00,  10.00]
   w_com_via:       [ 0.0001,  0.0001,  500.000]

--- a/momentumopt_configs/cfg_softConstraints_solo.yaml
+++ b/momentumopt_configs/cfg_softConstraints_solo.yaml
@@ -22,7 +22,7 @@ planner_variables:
 
   gravity: 9.81
   robot_mass: 2.5
-  friction_coeff: 0.9
+  friction_coeff: 0.3
   friction_cone: LinearCone  # Types: LinearCone, SocCone #
   torque_range: [-10.0, 10.0]
   eff_offset_rf: [0.19, -0.15, 0]
@@ -42,9 +42,9 @@ planner_variables:
   w_time: 1000.0 # weight of the cost to keep the defined duration of each phases
   w_com:           [ 1000,  1000,  100]
   w_amom:          [ 0.500,  0.500,  0.500]
-  w_lmom:          [ 1,  10.,  0.1]
+  w_lmom:          [ 0.2,  10.,  0.1]
   w_amomd:         [ 0.100,  0.400,  0.100]
-  w_lmomd:         [ 0.1,  1.,  0.5]
+  w_lmomd:         [ 0.01,  1.,  0.5]
   w_amom_final:    [ 10.00,  10.00,  10.00]
   w_lmom_final:    [ 10.00,  10.00,  10.00]
   w_com_via:       [ 0.0001,  0.0001,  500.000]

--- a/momentumopt_configs/cfg_softConstraints_solo.yaml
+++ b/momentumopt_configs/cfg_softConstraints_solo.yaml
@@ -1,0 +1,61 @@
+planner_variables:
+
+  load_kinematics: false
+  display_motion: false
+
+  floor_height: 0.0 # offset between the contact position and the 'floor' surface used to constraint the height
+  min_rel_height: 0.15 # minimum allowed distance from the robot CoM to the floor
+
+  heuristic: TrustRegion  # Types: TrustRegion, SoftConstraint, TimeOptimization #
+  n_act_eefs: 4
+  time_step: 0.05
+  time_horizon: 0. # duration of the motion, will be overwrited by the value inside the contact sequence
+  time_range: [0.01, 0.2] # Bounds on the value of dt during time optimization
+  is_time_horizon_fixed: false # Allow to change the total duration of the motion
+  external_force: [0.00, 0.00, 0.00]
+  com_displacement: [0., 0., 0.]
+  num_com_viapoints: 0
+  com_viapoints:
+  max_time_iterations: 10000
+  max_time_residual_tolerance: 1e-3
+  min_time_residual_improvement: 1e-5
+
+  gravity: 9.81
+  robot_mass: 2.5
+  friction_coeff: 0.7
+  friction_cone: LinearCone  # Types: LinearCone, SocCone #
+  torque_range: [-25.0, 25.0]
+  eff_offset_rf: [0.19, -0.15, 0]
+  eff_offset_lf: [0.19, 0.15, 0]
+  eff_offset_rh: [-0.19, -0.15 ,0]
+  eff_offset_lh: [-0.19, 0.15 ,0]
+  cop_range_rf: [-0.005,  0.005, -0.005,  0.005]
+  cop_range_lf: [-0.005,  0.005, -0.005,  0.005]
+  cop_range_rh: [-0.005,  0.005, -0.005,  0.005]
+  cop_range_lh: [-0.005,  0.005, -0.005,  0.005]
+  max_eef_lengths: [0.3,  0.3,  0.3,  0.3]
+  #max_eef_lengths: [0.6,  0.6,  0.6,  0.6]
+
+  w_trq_arm:       1.000
+  w_trq_leg:       1.000
+  w_time_penalty: 100. # weight of the cost to reduce the total duration of the motion
+  w_time: 1000.0 # weight of the cost to keep the defined duration of each phases
+  w_com:           [ 10000,  10000,  1000]
+  w_amom:          [ 0.500,  0.500,  0.500]
+  w_lmom:          [ 0.010,  0.001,  0.001]
+  w_amomd:         [ 0.100,  0.400,  0.100]
+  w_lmomd:         [ 0.015,  0.015,  0.015]
+  w_amom_final:    [ 10.00,  10.00,  10.00]
+  w_lmom_final:    [ 10.00,  10.00,  10.00]
+  w_com_via:       [ 0.2,  0.2,  500.000]
+  w_frc_arm:       [ 0.001,  0.001,  0.001]
+  w_frc_leg:       [ 0.001,  0.001,  0.001]
+  w_dfrc_arm:      [ 0.000,  0.000,  0.000]
+  w_dfrc_leg:      [ 0.000,  0.000,  0.000]
+  w_com_track:     [ 0.000,  0.000,  0.000]  # weight used to track the CoM position from the Kinematic Sequence
+  w_amom_track:    [ 1.000,  1.000,  1.000]
+  w_lmom_track:    [ 0.100,  0.100,  0.100]
+
+
+  store_data: True
+  use_default_solver_setting: True

--- a/momentumopt_configs/cfg_softConstraints_solo_lowgoal.yaml
+++ b/momentumopt_configs/cfg_softConstraints_solo_lowgoal.yaml
@@ -40,7 +40,7 @@ planner_variables:
   w_trq_leg:       1.000
   w_time_penalty: 100. # weight of the cost to reduce the total duration of the motion
   w_time: 1000.0 # weight of the cost to keep the defined duration of each phases
-  w_com:           [ 1000,  1000,  100]
+  w_com:           [ 100,  100,  100]
   w_amom:          [ 0.500,  0.500,  0.500]
   w_lmom:          [ 1.,  2.,  0.001]
   w_amomd:         [ 0.100,  0.400,  0.100]

--- a/python/mlp/config.py
+++ b/python/mlp/config.py
@@ -83,6 +83,9 @@ class Config:
         ###  Settings for generate_contact_sequence
         self.FORCE_STRAIGHT_LINE = False  # DEBUG ONLY should be false
         self.SL1M_USE_ORIENTATION = True  # sl1m method use the root orientation computed by the guide planning
+        self.SL1M_USE_MIP = False  #  select between the L1 solver or the MIP solver (the later allow acyclic motion but is a lot slower)
+        self.SL1M_USE_INTERSECTION = True  # if True, the list of candidate contact surface given to SL1M
+        # are the intersection between the surfaces and the ROMs. If False, the complete surfaces are given
         self.GUIDE_STEP_SIZE = 1. # initial discretization step of the guide path used to find the surfaces for SL1M
         self.GUIDE_MAX_YAW = 0.2 # maximal yaw rotation difference between two discretization step
         self.MAX_SURFACE_AREA = 1. # if a contact surface is greater than this value, the intersection is used instead of the whole surface

--- a/python/mlp/config.py
+++ b/python/mlp/config.py
@@ -20,7 +20,7 @@ class Config:
 
     def __init__(self):
         ## methods setting : choose which method will be used to solve each subproblem :
-        self.contact_generation_method = "rbprm"
+        self.contact_generation_method = "load"
         self.centroidal_initGuess_method = "none"
         self.centroidal_method = "momentumopt"
         self.end_effector_initGuess_method = "bezier_predef"
@@ -74,7 +74,7 @@ class Config:
         self.DISPLAY_WB_MOTION = False  # display whole body motion automatically once it's computed
         # dt used to display the wb motion (one configuration every dt is displayed) It have to be greater than IK_dt
         self.DT_DISPLAY = 0.05
-        self.PLOT = False  # Generate plot for various data
+        self.PLOT = True  # Generate plot for various data
         # plot COM trajectory computed by the centroidal dynamic solver, before trying to compute the wholebody motion
         self.PLOT_CENTROIDAL = False
         self.DISPLAY_PLOT = self.PLOT and True  # display plot directly
@@ -123,12 +123,12 @@ class Config:
         self.CHECK_FINAL_MOTION = True  # After computation of the motion, check the complete motion for {self-}collision and joints limits
         ### The following settings enable the computation of various values stored in the wholeBody_result struct.
         # Enabling them increase the computation time of the wholeBody script
-        self.IK_store_centroidal = False  # c,dc,ddc,L,dL (of the computed wholebody motion)
-        self.IK_store_zmp = False
-        self.IK_store_effector = False
-        self.IK_store_contact_forces = False
-        self.IK_store_joints_derivatives = False
-        self.IK_store_joints_torque = False
+        self.IK_store_centroidal = True  # c,dc,ddc,L,dL (of the computed wholebody motion)
+        self.IK_store_zmp = True
+        self.IK_store_effector = True
+        self.IK_store_contact_forces = True
+        self.IK_store_joints_derivatives = True
+        self.IK_store_joints_torque = True
 
         self.DEMO_NAME = "undefined"
         self.CS_FILENAME = self.CONTACT_SEQUENCE_PATH + "/" + self.DEMO_NAME + ".cs"

--- a/python/mlp/config.py
+++ b/python/mlp/config.py
@@ -85,6 +85,8 @@ class Config:
         self.SL1M_USE_ORIENTATION = True  # sl1m method use the root orientation computed by the guide planning
         self.SL1M_USE_MIP = False  #  select between the L1 solver or the MIP solver (the later allow acyclic motion but is a lot slower)
         self.SL1M_USE_INTERSECTION = True  # if True, the list of candidate contact surface given to SL1M
+        self.SL1M_MAX_STEP = -1  # Maximum number of phases per SL1M call, if negative: unlimited
+
         # are the intersection between the surfaces and the ROMs. If False, the complete surfaces are given
         self.GUIDE_STEP_SIZE = 1. # initial discretization step of the guide path used to find the surfaces for SL1M
         self.GUIDE_MAX_YAW = 0.2 # maximal yaw rotation difference between two discretization step

--- a/python/mlp/contact_sequence/manually_defined/solo_walk.py
+++ b/python/mlp/contact_sequence/manually_defined/solo_walk.py
@@ -20,7 +20,7 @@ limbs = fb.limbs_names
 q_ref = fb.referenceConfig[::] + [0] * 6
 addPhaseFromConfig(fb, cs, q_ref, limbs)
 
-walk(fb, cs, 1., 0.1, limbs, first_half_step=False)
+walk(fb, cs, 0.5, 0.1, limbs, first_half_step=False)
 
 display_tools.displaySteppingStones(cs, gui, sceneName, fb)
 

--- a/python/mlp/contact_sequence/manually_defined/solo_walk.py
+++ b/python/mlp/contact_sequence/manually_defined/solo_walk.py
@@ -18,10 +18,9 @@ cs = ContactSequence(0)
 limbs = fb.limbs_names
 #Create an initial contact phase :
 q_ref = fb.referenceConfig[::] + [0] * 6
-addPhaseFromConfig(fb, cs, q_ref, limbs, t_init=0)
-cs.contactPhases[-1].time_final = 1.
+addPhaseFromConfig(fb, cs, q_ref, limbs)
 
-walk(fb, cs, 1., 0.07, limbs, duration_ss=0.5, duration_ds=0.2)
+walk(fb, cs, 1., 0.12, limbs)
 
 display_tools.displaySteppingStones(cs, gui, sceneName, fb)
 

--- a/python/mlp/contact_sequence/manually_defined/solo_walk.py
+++ b/python/mlp/contact_sequence/manually_defined/solo_walk.py
@@ -20,7 +20,7 @@ limbs = fb.limbs_names
 q_ref = fb.referenceConfig[::] + [0] * 6
 addPhaseFromConfig(fb, cs, q_ref, limbs)
 
-walk(fb, cs, 1., 0.12, limbs)
+walk(fb, cs, 1., 0.1, limbs, first_half_step=False)
 
 display_tools.displaySteppingStones(cs, gui, sceneName, fb)
 

--- a/python/mlp/contact_sequence/manually_defined/solo_walk.py
+++ b/python/mlp/contact_sequence/manually_defined/solo_walk.py
@@ -1,0 +1,30 @@
+from mlp.utils.cs_tools import addPhaseFromConfig
+import multicontact_api
+from multicontact_api import ContactSequence
+import mlp.viewer.display_tools as display_tools
+from pinocchio import SE3
+from numpy import array
+from mlp.utils.cs_tools import walk
+from solo_rbprm.solo import Robot  # change robot here
+multicontact_api.switchToNumpyArray()
+
+ENV_NAME = "multicontact/ground"
+
+fb, v = display_tools.initScene(Robot, ENV_NAME, False)
+gui = v.client.gui
+sceneName = v.sceneName
+cs = ContactSequence(0)
+
+limbs = fb.limbs_names
+#Create an initial contact phase :
+q_ref = fb.referenceConfig[::] + [0] * 6
+addPhaseFromConfig(fb, cs, q_ref, limbs, t_init=0)
+cs.contactPhases[-1].time_final = 1.
+
+walk(fb, cs, 1., 0.07, limbs, duration_ss=0.5, duration_ds=0.2)
+
+display_tools.displaySteppingStones(cs, gui, sceneName, fb)
+
+filename = "solo_flatGround.cs"
+print("Write contact sequence binary file : ", filename)
+cs.saveAsBinary(filename)

--- a/python/mlp/contact_sequence/sl1m.py
+++ b/python/mlp/contact_sequence/sl1m.py
@@ -267,8 +267,9 @@ def solve(planner, cfg, display_surfaces = False, initial_contacts = None):
             initCom = np.array(planner.q_init[0:3])
             endCom = np.array(planner.q_goal[0:3])
             pb, res, time = solveMIPGurobi(pb, surfaces, MIP=True, draw_scene=None, plot=True, l1Contact=False,
-                                           initPos=None, endPos=None, initCom=initCom, endCom=endCom,
-                                           costs=[(10, targetCom)])
+                                           initPos=initial_contacts, endPos=None, initCom=initCom, endCom=endCom,
+                                           costs=[(0.01, posturalCost),(10, targetCom)],
+                                           constraint_init_pos_surface = False)
             coms, footpos, allfeetpos = retrieve_points_from_res(pb, res)
             success = True # FIXME check this from mip outputs ?
         else:

--- a/python/mlp/contact_sequence/sl1m.py
+++ b/python/mlp/contact_sequence/sl1m.py
@@ -1,5 +1,5 @@
 try:
-    from sl1m.planner import *
+    import sl1m.planner as sl1m
 except ImportError:
     message = "ERROR: Cannot import SL1M python library.\n"
     message += "Did you correctly installed it?\n"
@@ -16,10 +16,13 @@ from pinocchio import Quaternion, SE3
 from hpp.corbaserver.rbprm.tools.surfaces_from_path import getSurfacesFromGuideContinuous
 import random
 from mlp.utils.requirements import Requirements
+import numpy as np
+from numpy import array
+from numpy.linalg import norm
 import logging
 logging.basicConfig(format='[%(name)-12s] %(levelname)-8s: %(message)s')
 logger = logging.getLogger("sl1m")
-logger.setLevel(logging.ERROR) #DEBUG, INFO or WARNING
+logger.setLevel(logging.DEBUG) #DEBUG, INFO or WARNING
 multicontact_api.switchToNumpyArray()
 
 class ContactOutputsSl1m(Requirements):
@@ -27,74 +30,18 @@ class ContactOutputsSl1m(Requirements):
 
 Z_AXIS = np.array([0, 0, 1])
 EPS_Z = 0.005  # offset added to feet z position, otherwise there is collisions with the ground
+USE_MIP = True # if True, use the MIP formulation: no gait specified, but slower computation time
 
-##### MOVE the next methods to a robot-specific file : #####
-import os
-# load  constraints
+# global vars that hold constraints for MIP
+__ineq_com = []
+__ineq_relative = []
+# global vars that hold constraints for sl1m
 __ineq_right_foot = None
 __ineq_left_foot = None
 __ineq_right_foot_reduced = None
 __ineq_left_foot_reduced = None
-
-
-# add foot offset
-def right_foot_constraints(transform):
-    global __ineq_right_foot
-    if __ineq_right_foot is None:
-        filekin = os.environ[
-            "INSTALL_HPP_DIR"] \
-            + "/share/talos-rbprm/com_inequalities/feet_quasi_flat/talos_COM_constraints_in_RF_effector_frame_REDUCED.obj"
-        obj = load_obj(filekin)
-        __ineq_right_foot = as_inequalities(obj)
-    transform2 = transform.copy()
-    transform2[2, 3] += 0.105
-    ine = rotate_inequalities(__ineq_right_foot, transform2)
-    return (ine.A, ine.b)
-
-
-def left_foot_constraints(transform):
-    global __ineq_left_foot
-    if __ineq_left_foot is None:
-        filekin = os.environ[
-            "INSTALL_HPP_DIR"] \
-            + "/share/talos-rbprm/com_inequalities/feet_quasi_flat/talos_COM_constraints_in_LF_effector_frame_REDUCED.obj"
-        obj = load_obj(filekin)
-        __ineq_left_foot = as_inequalities(obj)
-    transform2 = transform.copy()
-    transform2[2, 3] += 0.105
-    ine = rotate_inequalities(__ineq_left_foot, transform2)
-    return (ine.A, ine.b)
-
-
 __ineq_rf_in_rl = None
 __ineq_lf_in_rf = None
-
-
-# add foot offset
-def right_foot_in_lf_frame_constraints(transform):
-    global __ineq_rf_in_rl
-    if __ineq_rf_in_rl is None:
-        filekin = os.environ[
-            "INSTALL_HPP_DIR"] \
-            + "/share/talos-rbprm/relative_effector_positions/talos_RF_constraints_in_LF_quasi_flat_REDUCED.obj"
-        obj = load_obj(filekin)
-        __ineq_rf_in_rl = as_inequalities(obj)
-    transform2 = transform.copy()
-    ine = rotate_inequalities(__ineq_rf_in_rl, transform2)
-    return (ine.A, ine.b)
-
-
-def left_foot_in_rf_frame_constraints(transform):
-    global __ineq_lf_in_rf
-    if __ineq_lf_in_rf is None:
-        filekin = os.environ[
-            "INSTALL_HPP_DIR"] \
-            + "/share/talos-rbprm/relative_effector_positions/talos_LF_constraints_in_RF_quasi_flat_REDUCED.obj"
-        obj = load_obj(filekin)
-        __ineq_lf_in_rf = as_inequalities(obj)
-    transform2 = transform.copy()
-    ine = rotate_inequalities(__ineq_lf_in_rf, transform2)
-    return (ine.A, ine.b)
 
 
 ####################################
@@ -120,11 +67,12 @@ def quatToConfig(quat):
     return [quat.x, quat.y, quat.z, quat.w]
 
 
-# FIXME : HARDCODED stuff for talos in this method !
-def initial_foot_pose_from_guide(root_init, ref_root_height):
-    lf_0 = array(root_init[0:3]) + array([0, 0.085, -ref_root_height])  # values for talos !
-    rf_0 = array(root_init[0:3]) + array([0, -0.085, -ref_root_height])  # values for talos !
-    return lf_0, rf_0
+def initial_foot_pose_from_guide(Robot, root_init):
+    return [array(root_init[0:3]) + Robot.dict_ref_effector_from_root[limb_name] for limb_name in Robot.limbs_names]
+    return  [array([0.38437629, 0.18974121, 0.00091648]),
+ array([ 0.38437629, -0.18974121,  0.00091648]),
+ array([-0.38437629,  0.18974121,  0.00091648]),
+ array([-0.38437629, -0.18974121,  0.00091648])]
 
 
 def initial_foot_pose_from_fullbody(fullbody, q_init):
@@ -134,20 +82,54 @@ def initial_foot_pose_from_fullbody(fullbody, q_init):
     return lf_0, rf_0
 
 
-def gen_pb(lf_0, rf_0, R, surfaces):
+def gen_pb(Robot, initial_contacts, R, surfaces):
+    #  Nested function declaration, as they need access to the Robot variable:
+    def right_foot_constraints(transform):
+        global __ineq_right_foot
+        if __ineq_right_foot is None:
+            obj = sl1m.load_obj(Robot.filekin_right)
+            __ineq_right_foot = sl1m.as_inequalities(obj)
+        transform2 = transform.copy()
+        transform2[2, 3] += 0.105
+        ine = sl1m.rotate_inequalities(__ineq_right_foot, transform2)
+        return (ine.A, ine.b)
+
+    def left_foot_constraints(transform):
+        global __ineq_left_foot
+        if __ineq_left_foot is None:
+            obj = sl1m.load_obj(Robot.filekin_left)
+            __ineq_left_foot = sl1m.as_inequalities(obj)
+        transform2 = transform.copy()
+        transform2[2, 3] += 0.105
+        ine = sl1m.rotate_inequalities(__ineq_left_foot, transform2)
+        return (ine.A, ine.b)
+
+    # add foot offset
+    def right_foot_in_lf_frame_constraints(transform):
+        global __ineq_rf_in_rl
+        if __ineq_rf_in_rl is None:
+            obj = sl1m.load_obj(Robot.file_rf_in_lf)
+            __ineq_rf_in_rl = sl1m.as_inequalities(obj)
+        transform2 = transform.copy()
+        ine = sl1m.rotate_inequalities(__ineq_rf_in_rl, transform2)
+        return (ine.A, ine.b)
+
+    def left_foot_in_rf_frame_constraints(transform):
+        global __ineq_lf_in_rf
+        if __ineq_lf_in_rf is None:
+            obj = sl1m.load_obj(Robot.file_lf_in_rf)
+            __ineq_lf_in_rf = sl1m.as_inequalities(obj)
+        transform2 = transform.copy()
+        ine = sl1m.rotate_inequalities(__ineq_lf_in_rf, transform2)
+        return (ine.A, ine.b)
+
     logger.debug("surfaces = %s",surfaces)
     logger.info("number of surfaces : %d", len(surfaces))
     logger.info("number of rotation matrix for root : %d", len(R))
     nphases = len(surfaces)
-    logger.info("lf_0 = ", lf_0)
-    logger.info("rf_0 = ", rf_0)
-    #init_floor_height = surfaces[0][0][2][0]
-    # z value of the first surface in intersection with the rom in the initial configuration
-    #lf_0[2] = init_floor_height
-    #rf_0[2] = init_floor_height
-    p0 = [lf_0, rf_0]
-    logger.info("p0 used : %s", p0)
-    res = {"p0": p0, "c0": None, "nphases": nphases}
+    logger.info("init_contacts = %s", initial_contacts)
+
+    res = {"p0": initial_contacts, "c0": None, "nphases": nphases}
     #print "number of rotations values : ",len(R)
     #print "R= ",R
     #TODO in non planar cases, K must be rotated
@@ -156,11 +138,11 @@ def gen_pb(lf_0, rf_0, R, surfaces):
         i % 2,
         "fixed": (i + 1) % 2,
         "K": [
-            genKinematicConstraints(left_foot_constraints, right_foot_constraints, index=i, rotation=R, min_height=0.3)
+            sl1m.genKinematicConstraints(left_foot_constraints, right_foot_constraints, index=i, rotation=R, min_height=0.3)
             for _ in range(len(surfaces[i]))
         ],
         "relativeK": [
-            genFootRelativeConstraints(right_foot_in_lf_frame_constraints,
+            sl1m.genFootRelativeConstraints(right_foot_in_lf_frame_constraints,
                                        left_foot_in_rf_frame_constraints,
                                        index=i,
                                        rotation=R)[(i) % 2] for _ in range(len(surfaces[i]))
@@ -173,20 +155,88 @@ def gen_pb(lf_0, rf_0, R, surfaces):
     res["phaseData"] = phaseData
     return res
 
+## Helper methods to load constraints :
+# add foot offset
+def com_in_limb_effector_frame_constraint(Robot, transform, limbId):
+    global __ineq_com
+    assert (limbId <= len(Robot.limbs_names))
+    limb_name = Robot.limbs_names[limbId]
+    if __ineq_com[limbId] is None:
+        filekin = Robot.kinematic_constraints_path +"/COM_constraints_in_"+limb_name+ "_effector_frame_quasi_static_reduced.obj"
+        obj = sl1m.load_obj(filekin)
+        __ineq_com[limbId] = sl1m.as_inequalities(obj)
+    transform2 = transform.copy()
+    # ~ transform2[2,3] += 0.105
+    ine = sl1m.rotate_inequalities(__ineq_com[limbId], transform2)
+    return ine.A, ine.b
 
-def solve(planner, guide_step_size, guide_max_yaw, max_surface_area, display_surfaces = False, initial_contacts = None):
-    from sl1m.fix_sparsity import solveL1
-    #surfaces_dict = getAllSurfacesDict(planner.afftool)
+
+def realIdxFootId(limbId, footId):
+    if footId > limbId:
+        return footId -1
+    return footId
+
+# add foot offset
+def foot_in_limb_effector_frame_constraint(Robot, transform, limbId, footId):
+    global __ineq_relative
+    assert (limbId != footId)
+    limb_name = Robot.limbs_names[limbId]
+    eff_name = Robot.dict_limb_joint[Robot.limbs_names[footId]]
+    if __ineq_relative[limbId][realIdxFootId(limbId,footId)] is None:
+        filekin = Robot.relative_feet_constraints_path + "/" + eff_name + "_constraints_in_" + limb_name + "_reduced.obj"
+        obj = sl1m.load_obj(filekin)
+        __ineq_relative[limbId][realIdxFootId(limbId,footId)] = sl1m.as_inequalities(obj)
+    transform2 = transform.copy()
+    ine = sl1m.rotate_inequalities(__ineq_relative[limbId][realIdxFootId(limbId,footId)], transform2)
+    return ine.A, ine.b
+
+def genCOMConstraints(Robot, rotation, normals):
+    return [com_in_limb_effector_frame_constraint(Robot, sl1m.default_transform_from_pos_normal_(rotation, sl1m.zero3, normals[idx]),idx)
+            for idx in range(len(Robot.limbs_names))]
+
+def genRelativeConstraints(Robot, rotation, normals):
+    transforms = [sl1m.default_transform_from_pos_normal_(rotation, sl1m.zero3, normals[idx])
+                  for idx in range(len(Robot.limbs_names))]
+    res = []
+    for limbId, transform in enumerate(transforms):
+        res += [[(footId, foot_in_limb_effector_frame_constraint(Robot, transform, limbId, footId))
+                 for footId in range(len(Robot.limbs_names)) if footId != limbId]]
+    return res
+
+
+def gen_pb_mip(Robot, R, surfaces):
+    #  Nested function declaration, as they need access to the Robot variable:
+    normals = [np.array([0, 0, 1]) for _ in range(len(Robot.limbs_names))] #FIXME: compute it from the surfaces
+    logger.debug("surfaces = %s",surfaces)
+    logger.info("number of surfaces : %d", len(surfaces))
+    logger.info("number of rotation matrix for root : %d", len(R))
+    nphases = len(surfaces)
+    res = {"p0": None, "c0": None, "nphases": nphases}
+    #TODO in non planar cases, K must be rotated
+    phaseData = [{
+        "K": [genCOMConstraints(Robot, R[i], normals) for _ in range(len(surfaces[i]))],
+        "allRelativeK": [genRelativeConstraints(Robot, R[i], normals) for _ in range(len(surfaces[i]))],
+        "rootOrientation":R[i],
+        "S": surfaces[i]
+    } for i in range(nphases)]
+    res["phaseData"] = phaseData
+    return res
+
+def solve(planner, cfg, display_surfaces = False, initial_contacts = None):
+    if USE_MIP:
+        num_eff = len(cfg.Robot.limbs_names) # number of effectors used to create contacts
+        global __ineq_com
+        global __ineq_relative
+        __ineq_com = [None for _ in range(num_eff)]
+        __ineq_relative = [[None for _ in range(num_eff - 1)] for __ in range(num_eff)]
     if initial_contacts is None:
-        lf_0, rf_0 = initial_foot_pose_from_guide(planner.q_init, planner.rbprmBuilder.ref_height)
-    else:
-        #FIXME : assume order and size of arguments, do something more generic
-        lf_0 = initial_contacts[0]
-        rf_0 = initial_contacts[1]
+        initial_contacts = initial_foot_pose_from_guide(cfg.Robot, planner.q_init)
+
+    #  Extract candidate surfaces and root rotation from the guide planning
     success = False
     maxIt = 50
     it = 0
-    defaultStep = guide_step_size
+    defaultStep = cfg.GUIDE_STEP_SIZE
     step = defaultStep
     variation = 0.4  # FIXME : put it in config file, +- bounds on the step size
     if hasattr(planner, "pathId"):
@@ -198,8 +248,6 @@ def solve(planner, guide_step_size, guide_max_yaw, max_surface_area, display_sur
     while not success and it < maxIt:
         if it > 0:
             step = defaultStep + random.uniform(-variation, variation)
-        #configs = getConfigsFromPath (planner.ps, planner.pathId, step)
-        #getSurfacesFromPath(planner.rbprmBuilder, configs, surfaces_dict, planner.v, True, False)
         viewer = planner.v
         if not hasattr(viewer, "client"):
             viewer = None
@@ -209,15 +257,29 @@ def solve(planner, guide_step_size, guide_max_yaw, max_surface_area, display_sur
                                                      pathId,
                                                      viewer if display_surfaces else None,
                                                      step,
-                                                     useIntersection=True,
-                                                     max_yaw=guide_max_yaw,
-                                                     max_surface_area=max_surface_area)
-        pb = gen_pb(lf_0, rf_0, R, surfaces)
-        try:
-            pb, coms, footpos, allfeetpos, res = solveL1(pb, surfaces, None)
-            success = True
-        except:
-            logger.warning("## Planner failed at iter : %d with step length = %f", it, step)
+                                                     useIntersection=False,
+                                                     max_yaw=cfg.GUIDE_MAX_YAW,
+                                                     max_surface_area=cfg.MAX_SURFACE_AREA)
+        if USE_MIP:
+            from sl1m.planner_l1_generic_equalities_as_ineq import solveMIPGurobi, initGlobals, posturalCost, targetCom, \
+                retrieve_points_from_res
+            initGlobals(nEffectors=num_eff)
+            pb = gen_pb_mip(cfg.Robot, R, surfaces)
+            initCom = np.array(planner.q_init[0:3])
+            endCom = np.array(planner.q_goal[0:3])
+            pb, res, time = solveMIPGurobi(pb, surfaces, MIP=True, draw_scene=None, plot=True, l1Contact=False,
+                                           initPos=None, endPos=None, initCom=initCom, endCom=endCom,
+                                           costs=[(10, targetCom)])
+            coms, footpos, allfeetpos = retrieve_points_from_res(pb, res)
+            success = True # FIXME check this from mip outputs ?
+        else:
+            from sl1m.fix_sparsity import solveL1
+            pb = gen_pb(cfg.Robot, initial_contacts, R, surfaces)
+            try:
+                pb, coms, footpos, allfeetpos, res = solveL1(pb, surfaces, None)
+                success = True
+            except:
+                logger.warning("## Planner failed at iter : %d with step length = %f", it, step)
         it += 1
     if not success:
         raise RuntimeError("planner always fail.")
@@ -236,12 +298,10 @@ def runLPFromGuideScript(cfg):
     planner = module.PathPlanner()
     planner.run()
     # compute sequence of surfaces from guide path
-    pathId, pb, coms, footpos, allfeetpos, res = solve(planner, cfg.GUIDE_STEP_SIZE, cfg.GUIDE_MAX_YAW,
-                                                       cfg.MAX_SURFACE_AREA,
-                                                       cfg.DISPLAY_SL1M_SURFACES)
+    pathId, pb, coms, footpos, allfeetpos, res = solve(planner, cfg, cfg.DISPLAY_SL1M_SURFACES)
     root_init = planner.ps.configAtParam(pathId, 0.001)[0:7]
     root_end = planner.ps.configAtParam(pathId, planner.ps.pathLength(pathId) - 0.001)[0:7]
-    return RF, root_init, root_end, pb, coms, footpos, allfeetpos, res
+    return sl1m.RF, root_init, root_end, pb, coms, footpos, allfeetpos, res
 
 
 def runLPScript(cfg):
@@ -266,7 +326,11 @@ def generate_contact_sequence_sl1m(cfg):
     fb, v = initScene(cfg.Robot, cfg.ENV_NAME, True)
     q_init = cfg.IK_REFERENCE_CONFIG.tolist() + [0] * 6
     q_init[0:7] = root_init
-    feet_height_init = allfeetpos[0][2]
+    if USE_MIP:
+        # if MIP is used, allfeetpos contains a list of all position and not just the new position
+        feet_height_init = allfeetpos[0][0][2]
+    else:
+        feet_height_init = allfeetpos[0][2]
     logger.info("feet height initial = %s", feet_height_init)
     q_init[2] = feet_height_init + cfg.IK_REFERENCE_CONFIG[2]
     q_init[2] += EPS_Z
@@ -274,13 +338,40 @@ def generate_contact_sequence_sl1m(cfg):
     if v:
         v(q_init)
 
-    cs = build_cs_from_sl1m(fb, cfg.IK_REFERENCE_CONFIG, root_end, pb, RF, allfeetpos,
+    if USE_MIP:
+        cs = build_cs_from_sl1m_mip(fb, cfg.IK_REFERENCE_CONFIG, root_end, pb, RF, allfeetpos, coms,
+                                cfg.SL1M_USE_ORIENTATION, cfg.SL1M_USE_INTERPOLATED_ORIENTATION, q_init=q_init)
+    else:
+        cs = build_cs_from_sl1m(fb, cfg.IK_REFERENCE_CONFIG, root_end, pb, RF, allfeetpos,
                             cfg.SL1M_USE_ORIENTATION, cfg.SL1M_USE_INTERPOLATED_ORIENTATION, q_init = q_init)
 
     if cfg.DISPLAY_CS_STONES:
         displaySteppingStones(cs, v.client.gui, v.sceneName, fb)
 
     return cs, fb, v
+
+def compute_orientation_for_feet_placement(fb, pb, pId, moving, RF, prev_contactPhase, use_interpolated_orientation):
+    quat0 = Quaternion(pb["phaseData"][pId]["rootOrientation"])
+    if pId < len(pb["phaseData"]) - 1:
+        quat1 = Quaternion(pb["phaseData"][pId + 1]["rootOrientation"])
+    else:
+        quat1 = Quaternion(pb["phaseData"][pId]["rootOrientation"])
+    if use_interpolated_orientation:
+        rot = quat0.slerp(0.5, quat1)
+        # check if feets do not cross :
+        if moving == RF:
+            qr = rot
+            ql = Quaternion(prev_contactPhase.contactPatch(fb.lfoot).placement.rotation)
+        else:
+            ql = rot
+            qr = Quaternion(prev_contactPhase.contactPatch(fb.rfoot).placement.rotation)
+        rpy = matrixToRpy((qr * (ql.inverse())).matrix())  # rotation from the left foot pose to the right one
+        if rpy[2] > 0:  # yaw positive, feet are crossing
+            rot = quat0  # rotation of the root, from the guide
+    else:
+        rot = quat0  # rotation of the root, from the guide
+    return rot
+
 
 def build_cs_from_sl1m(fb, q_ref, root_end, pb, RF, allfeetpos, use_orientation, use_interpolated_orientation,
                        q_init = None, first_phase = None):
@@ -307,25 +398,7 @@ def build_cs_from_sl1m(fb, q_ref, root_end, pb, RF, allfeetpos, use_orientation,
         pos[2] += EPS_Z  # FIXME it shouldn't be required !!
         # compute desired foot rotation :
         if use_orientation:
-            quat0 = Quaternion(pb["phaseData"][pId]["rootOrientation"])
-            if pId < len(pb["phaseData"]) - 1:
-                quat1 = Quaternion(pb["phaseData"][pId + 1]["rootOrientation"])
-            else:
-                quat1 = Quaternion(pb["phaseData"][pId]["rootOrientation"])
-            if  use_interpolated_orientation:
-                rot = quat0.slerp(0.5, quat1)
-                # check if feets do not cross :
-                if moving == RF:
-                    qr = rot
-                    ql = Quaternion(prev_contactPhase.contactPatch(fb.lfoot).placement.rotation)
-                else:
-                    ql = rot
-                    qr = Quaternion(prev_contactPhase.contactPatch(fb.rfoot).placement.rotation)
-                rpy = matrixToRpy((qr * (ql.inverse())).matrix())  # rotation from the left foot pose to the right one
-                if rpy[2] > 0:  # yaw positive, feet are crossing
-                    rot = quat0  # rotation of the root, from the guide
-            else:
-                rot = quat0  # rotation of the root, from the guide
+            rot = compute_orientation_for_feet_placement(fb, pb, pId, moving, RF, prev_contactPhase, use_interpolated_orientation)
         else:
             rot = Quaternion.Identity()
         placement = SE3()
@@ -348,4 +421,74 @@ def build_cs_from_sl1m(fb, q_ref, root_end, pb, RF, allfeetpos, use_orientation,
     com = fb.getCenterOfMass()
     setFinalState(cs, com, q=q_end)
 
+    return cs
+
+def build_cs_from_sl1m_mip(fb, q_ref, root_end, pb, RF, allfeetpos, coms, use_orientation, use_interpolated_orientation,
+                       q_init = None, first_phase = None):
+    # init contact sequence with first phase : q_ref move at the right root pose and with both feet in contact
+    # FIXME : allow to customize that first phase
+    num_steps = len(pb["phaseData"]) - 1 # number of contact repositionning
+    limbs_names = fb.limbs_names
+    num_effectors = len(limbs_names)
+    logger.info(" limbs names : %s", limbs_names)
+    cs = ContactSequence(0)
+    if first_phase:
+        cs.append(first_phase)
+    elif q_init:
+        # if only the configuration is provided, assume all effectors are in contact
+        addPhaseFromConfig(fb, cs, q_init, limbs_names)
+    else:
+        raise ValueError("build_cs_from_sl1m should have either q_init or first_phase argument defined")
+    logger.info("Initial phase added, contacts : %s ", cs.contactPhases[0].effectorsInContact())
+    # loop for all effector placements, and create the required contact phases
+    previous_eff_placements = allfeetpos[0]
+    if len(previous_eff_placements) != num_effectors:
+        raise NotImplementedError("A phase in the output of SL1M do not have all the effectors in contact.")
+    for pid, eff_placements in enumerate(allfeetpos[1:]):
+        logger.info("Loop allfeetpos, id = %d", pid)
+        if len(eff_placements) != num_effectors:
+            raise NotImplementedError("A phase in the output of SL1M do not have all the effectors in contact.")
+        switch = False # True if a repostionning have been detected
+        for k, pos in enumerate(eff_placements):
+            if norm(pos - previous_eff_placements[k]) > 1e-4:
+                if switch:
+                    raise NotImplementedError("Several contact changes between two adjacent phases in SL1M output")
+                switch = True
+                ee_name = fb.dict_limb_joint[limbs_names[k]]
+                logger.info("Move effector %s ", ee_name)
+                placement = SE3.Identity()
+                placement.translation = pos
+                # TODO compute rotation from guide here !
+                cs.moveEffectorToPlacement(ee_name, placement)
+
+        #if not switch:
+        #   raise RuntimeError("No contact changes between two adjacent phases in SL1M output")
+        # assign com position to the last two phases :
+        # swinging phase, same init and final position
+        """
+        cs.contactPhases[-2].c_init = coms[pid * 2]
+        cs.contactPhases[-2].c_final = coms[pid * 2 + 1]
+        # phase with all the contacts:
+        cs.contactPhases[-1].c_init = coms[pid * 2 + 1]
+        if pid * 2 + 2 < len(coms):
+            cs.contactPhases[-1].c_final = coms[pid * 2 + 2]
+        else:
+            cs.contactPhases[-1].c_final = cs.contactPhases[-1].c_init
+        """
+        previous_eff_placements = eff_placements
+
+    # final phase :
+    # fixme : assume root is in the middle of the last 2 feet pos ...
+    q_end = q_ref.tolist() + [0] * 6
+    # p_end = (allfeetpos[-1] + allfeetpos[-2]) / 2.
+    # for i in range(3):
+    #    q_end[i] += p_end[i]
+    q_end[0:7] = root_end
+    feet_height_end = allfeetpos[-1][0][2]
+    logger.info("feet height final = %s", feet_height_end)
+    q_end[2] = feet_height_end + q_ref[2]
+    q_end[2] += EPS_Z
+    fb.setCurrentConfig(q_end)
+    com = fb.getCenterOfMass()
+    setFinalState(cs, com, q=q_end)
     return cs

--- a/python/mlp/contact_sequence/sl1m.py
+++ b/python/mlp/contact_sequence/sl1m.py
@@ -9,7 +9,7 @@ from pinocchio.utils import *
 import importlib
 import multicontact_api
 from multicontact_api import ContactSequence
-from mlp.utils.cs_tools import addPhaseFromConfig, setFinalState
+from mlp.utils.cs_tools import addPhaseFromConfig, setFinalState, computeCenterOfSupportPolygonFromPhase
 from mlp.viewer.display_tools import initScene, displaySteppingStones
 from pinocchio.utils import matrixToRpy
 from pinocchio import Quaternion, SE3
@@ -477,6 +477,7 @@ def build_cs_from_sl1m_mip(fb, q_ref, root_end, pb, RF, allfeetpos, coms, use_or
 
     # final phase :
     # fixme : assume root is in the middle of the last 2 feet pos ...
+    """
     q_end = q_ref.tolist() + [0] * 6
     # p_end = (allfeetpos[-1] + allfeetpos[-2]) / 2.
     # for i in range(3):
@@ -485,8 +486,12 @@ def build_cs_from_sl1m_mip(fb, q_ref, root_end, pb, RF, allfeetpos, coms, use_or
     feet_height_end = allfeetpos[-1][0][2]
     logger.info("feet height final = %s", feet_height_end)
     q_end[2] = feet_height_end + q_ref[2]
-    q_end[2] += EPS_Z
+    #q_end[2] += EPS_Z
     fb.setCurrentConfig(q_end)
     com = fb.getCenterOfMass()
     setFinalState(cs, com, q=q_end)
+    """
+    p_final = cs.contactPhases[-1]
+    p_final.c_final = computeCenterOfSupportPolygonFromPhase(p_final, fb.DEFAULT_COM_HEIGHT)
+    p_final.c_init = p_final.c_final
     return cs

--- a/python/mlp/contact_sequence/sl1m.py
+++ b/python/mlp/contact_sequence/sl1m.py
@@ -58,15 +58,7 @@ def normal(phase):
     return n
 
 def normal_from_ineq(s_ineq):
-    logger.debug("s_ineq value : %s", s_ineq)
-    n = s_ineq[0][-1]
-    if n[2] < 0:
-        n = -n
-    n2 = s_ineq[2]
-    logger.debug("normal from ineq : %s", n)
-    logger.debug("normal stored : %s", n2)
-
-    return n2
+    return s_ineq[2]
 
 def quatConfigFromMatrix(m):
     quat = Quaternion(m)

--- a/python/mlp/contact_sequence/sl1m.py
+++ b/python/mlp/contact_sequence/sl1m.py
@@ -262,17 +262,19 @@ def solve(planner, cfg, display_surfaces = False, initial_contacts = None, final
                                                      step,
                                                      useIntersection=cfg.SL1M_USE_INTERSECTION,
                                                      max_yaw=cfg.GUIDE_MAX_YAW,
-                                                     max_surface_area=cfg.MAX_SURFACE_AREA)
+                                                     max_surface_area=cfg.MAX_SURFACE_AREA,
+                                                     use_all_limbs = cfg.SL1M_USE_MIP)
         if cfg.SL1M_USE_MIP:
             from sl1m.planner_l1_generic_equalities_as_ineq import solveMIPGurobi, initGlobals, posturalCost, targetCom, \
-                retrieve_points_from_res
+                retrieve_points_from_res, targetLegCenter, targetEndPos
             initGlobals(nEffectors=num_eff)
             pb = gen_pb_mip(cfg.Robot, R, surfaces)
             initCom = np.array(planner.q_init[0:3])
             endCom = np.array(planner.q_goal[0:3])
             pb, res, time = solveMIPGurobi(pb, surfaces, MIP=True, draw_scene=None, plot=True, l1Contact=False,
-                                           initPos=initial_contacts, endPos=None, initCom=initCom, endCom=endCom,
-                                           costs=[(0.01, posturalCost),(10, targetCom)],
+                                           initPos=initial_contacts, endPos=final_contacts,
+                                           initCom=initCom, endCom=endCom,
+                                           costs=[(1., posturalCost), (1., targetEndPos)],
                                            constraint_init_pos_surface = False)
             coms, footpos, allfeetpos = retrieve_points_from_res(pb, res)
             success = True # FIXME check this from mip outputs ?

--- a/python/mlp/contact_sequence/sl1m.py
+++ b/python/mlp/contact_sequence/sl1m.py
@@ -67,11 +67,8 @@ def quatToConfig(quat):
 
 
 def initial_foot_pose_from_guide(Robot, root_init):
-    return [array(root_init[0:3]) + Robot.dict_ref_effector_from_root[limb_name] for limb_name in Robot.limbs_names]
-    return  [array([0.38437629, 0.18974121, 0.00091648]),
- array([ 0.38437629, -0.18974121,  0.00091648]),
- array([-0.38437629,  0.18974121,  0.00091648]),
- array([-0.38437629, -0.18974121,  0.00091648])]
+    return [array(root_init[0:3]) + Robot.dict_ref_effector_from_root[limb_name] - array([0, 0, EPS_Z]) for limb_name in Robot.limbs_names]
+    # FIXME: apply epsz along the normal
 
 
 def initial_foot_pose_from_fullbody(fullbody, q_init):
@@ -230,7 +227,7 @@ def solve(planner, cfg, display_surfaces = False, initial_contacts = None):
         __ineq_relative = [[None for _ in range(num_eff - 1)] for __ in range(num_eff)]
     if initial_contacts is None:
         initial_contacts = initial_foot_pose_from_guide(cfg.Robot, planner.q_init)
-
+    logger.info("Initial contacts : %s", initial_contacts)
     #  Extract candidate surfaces and root rotation from the guide planning
     success = False
     maxIt = 50
@@ -456,6 +453,7 @@ def build_cs_from_sl1m_mip(fb, q_ref, root_end, pb, RF, allfeetpos, coms, use_or
                 switch = True
                 ee_name = fb.dict_limb_joint[limbs_names[k]]
                 logger.info("Move effector %s ", ee_name)
+                logger.info("To position %s ", pos)
                 placement = SE3.Identity()
                 placement.translation = pos
                 # TODO compute rotation from guide here !

--- a/python/mlp/contact_sequence/sl1m.py
+++ b/python/mlp/contact_sequence/sl1m.py
@@ -274,8 +274,9 @@ def solve(planner, cfg, display_surfaces = False, initial_contacts = None, final
             pb, res, time = solveMIPGurobi(pb, surfaces, MIP=True, draw_scene=None, plot=True, l1Contact=False,
                                            initPos=initial_contacts, endPos=final_contacts,
                                            initCom=initCom, endCom=endCom,
-                                           costs=[(1., posturalCost), (1., targetEndPos)],
-                                           constraint_init_pos_surface = False)
+                                           costs=[(5., posturalCost), (1., targetEndPos)],
+                                           constraint_init_pos_surface = False,
+                                           refPos = foot_pose_from_guide(cfg.Robot, [0, 0 ,planner.q_init[2]]))
             coms, footpos, allfeetpos = retrieve_points_from_res(pb, res)
             success = True # FIXME check this from mip outputs ?
         else:

--- a/python/mlp/demo_configs/anymal_flatGround.py
+++ b/python/mlp/demo_configs/anymal_flatGround.py
@@ -1,6 +1,6 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_anymal.yaml"
 from .common_anymal import *
-SCRIPT_PATH = "sandbox.ANYmal"
+SCRIPT_PATH = "demos"
 ENV_NAME = "multicontact/ground"
 
 DURATION_INIT = 2.  # Time to init the motion

--- a/python/mlp/demo_configs/common_anymal.py
+++ b/python/mlp/demo_configs/common_anymal.py
@@ -56,8 +56,10 @@ FEET_MAX_ANG_VEL = 1.5
 p_max = 0.2
 EFF_T_PREDEF = 0.
 
-GUIDE_STEP_SIZE = 0.3
+GUIDE_STEP_SIZE = 0.6
 SL1M_USE_MIP = True
+SL1M_USE_INTERSECTION = False
+
 
 import numpy as np
 gain_vector = np.ones(12)

--- a/python/mlp/demo_configs/common_anymal.py
+++ b/python/mlp/demo_configs/common_anymal.py
@@ -56,6 +56,8 @@ FEET_MAX_ANG_VEL = 1.5
 p_max = 0.2
 EFF_T_PREDEF = 0.
 
+GUIDE_STEP_SIZE = 0.3
+
 import numpy as np
 gain_vector = np.ones(12)
 masks_posture = np.zeros(12)

--- a/python/mlp/demo_configs/common_anymal.py
+++ b/python/mlp/demo_configs/common_anymal.py
@@ -57,6 +57,7 @@ p_max = 0.2
 EFF_T_PREDEF = 0.
 
 GUIDE_STEP_SIZE = 0.3
+SL1M_USE_MIP = True
 
 import numpy as np
 gain_vector = np.ones(12)

--- a/python/mlp/demo_configs/common_solo.py
+++ b/python/mlp/demo_configs/common_solo.py
@@ -30,6 +30,12 @@ level_posture = 1
 level_rootOrientation = 0
 level_am = 1
 
+# scaling and weight for the bounds tasks in TSID:
+w_torque_bounds = 1000.
+w_joint_bounds = 1000.
+scaling_torque_bounds = 1.5
+scaling_vel_bounds = 1.
+
 # The weight of the force regularization task of each contact will start at w_forceRef_init when creating a new contact,
 # and then linearly reduce to w_forceRef_end over a time period of phase_duration * w_forceRef_time_ratio
 w_forceRef_init = 1.

--- a/python/mlp/demo_configs/common_solo.py
+++ b/python/mlp/demo_configs/common_solo.py
@@ -14,7 +14,7 @@ fMax = 25.  # maximum normal force
 w_com = 1.0  # weight of center of mass task
 w_am =  2e-2
 w_am_track = 2e-2 # weight used for the tracking of the Angular momentum
-w_posture = 0.01  # weight of joint posture task
+w_posture = 10.  # weight of joint posture task
 w_rootOrientation = 0.1  # weight of the root's orientation task
 w_eff = 1.0  # weight of the effector motion task
 kp_contact = 50.0  # proportional gain of contact constraint
@@ -22,8 +22,8 @@ kp_com = 30.  # proportional gain of center of mass task
 kp_am = 20.
 kp_am_track = 20. # gain used for the tracking of the Angular momentum
 kp_posture = 10.  # proportional gain of joint posture task
-kp_rootOrientation = 5000.  # proportional gain of the root's orientation task
-kp_Eff = 100.  # proportional gain of the effectors motion task
+kp_rootOrientation = 50.  # proportional gain of the root's orientation task
+kp_Eff = 10.  # proportional gain of the effectors motion task
 level_eff = 0
 level_com = 0
 level_posture = 1
@@ -39,7 +39,7 @@ scaling_vel_bounds = 1.
 # The weight of the force regularization task of each contact will start at w_forceRef_init when creating a new contact,
 # and then linearly reduce to w_forceRef_end over a time period of phase_duration * w_forceRef_time_ratio
 w_forceRef_init = 1.
-w_forceRef_end = 1e-5
+w_forceRef_end = 1e-3
 w_forceRef_time_ratio = 0.5
 
 YAW_ROT_GAIN = 1.
@@ -65,15 +65,24 @@ FEET_MAX_ANG_VEL = 1.5
 p_max = 0.05
 EFF_T_PREDEF = 0.
 
+
 GUIDE_STEP_SIZE = 0.5
 SL1M_USE_MIP = True
-SL1M_USE_INTERSECTION = True
-SL1M_MAX_STEP = 10
+SL1M_USE_INTERSECTION = False
+SL1M_MAX_STEP = 6
 
 import numpy as np
 gain_vector = np.ones(12)
 masks_posture = np.zeros(12)
-for i in range(4):
-    masks_posture[2 + i * 3] = 1.  # knees
+
 
 IK_REFERENCE_CONFIG = np.array(Robot.referenceConfig)
+
+# for solo 8 : set a velocity bound to 0 for shoulder roll joint:
+scaling_vel_bounds = np.ones(12)
+
+for i in range(4):
+    masks_posture[i * 3] = 1.  # shoulder roll
+    scaling_vel_bounds[i * 3] = 0.
+    gain_vector[i * 3] = 1000.
+

--- a/python/mlp/demo_configs/common_solo.py
+++ b/python/mlp/demo_configs/common_solo.py
@@ -12,27 +12,27 @@ IK_dt = 0.002
 fMin = 1.0  # minimum normal force
 fMax = 25.  # maximum normal force
 w_com = 1.0  # weight of center of mass task
-w_am =  2e-2
-w_am_track = 2e-2 # weight used for the tracking of the Angular momentum
-w_posture = 10.  # weight of joint posture task
+w_am =  0.
+w_am_track = 0. # weight used for the tracking of the Angular momentum
+w_posture = 0.1  # weight of joint posture task
 w_rootOrientation = 0.1  # weight of the root's orientation task
 w_eff = 1.0  # weight of the effector motion task
 kp_contact = 50.0  # proportional gain of contact constraint
-kp_com = 30.  # proportional gain of center of mass task
+kp_com = 100.  # proportional gain of center of mass task
 kp_am = 20.
 kp_am_track = 20. # gain used for the tracking of the Angular momentum
 kp_posture = 10.  # proportional gain of joint posture task
 kp_rootOrientation = 50.  # proportional gain of the root's orientation task
 kp_Eff = 10.  # proportional gain of the effectors motion task
-level_eff = 0
-level_com = 0
+level_eff = 1
+level_com = 1
 level_posture = 1
-level_rootOrientation = 0
+level_rootOrientation = 1
 level_am = 1
 
 # scaling and weight for the bounds tasks in TSID:
-w_torque_bounds = 1000.
-w_joint_bounds = 1000.
+w_torque_bounds = 1.
+w_joint_bounds = 0.
 scaling_torque_bounds = 1.5
 scaling_vel_bounds = 1.
 
@@ -46,7 +46,7 @@ YAW_ROT_GAIN = 1.
 
 IK_eff_size = Robot.dict_size.copy()
 PLOT_CIRCLE_RADIUS = 0.01 # radius of the circle used to display the contacts
-SOLVER_DT = 0.05  # time step used for centroidal methods
+SOLVER_DT = 0.01  # time step used for centroidal methods
 
 # phases duration
 DURATION_INIT = 1.  # Time to init the motion
@@ -84,5 +84,5 @@ scaling_vel_bounds = np.ones(12)
 for i in range(4):
     masks_posture[i * 3] = 1.  # shoulder roll
     scaling_vel_bounds[i * 3] = 0.
-    gain_vector[i * 3] = 1000.
+    #gain_vector[i * 3] = 1.
 

--- a/python/mlp/demo_configs/common_solo.py
+++ b/python/mlp/demo_configs/common_solo.py
@@ -38,9 +38,9 @@ scaling_vel_bounds = 1.
 
 # The weight of the force regularization task of each contact will start at w_forceRef_init when creating a new contact,
 # and then linearly reduce to w_forceRef_end over a time period of phase_duration * w_forceRef_time_ratio
-w_forceRef_init = 1.
+w_forceRef_init = 10.
 w_forceRef_end = 1e-3
-w_forceRef_time_ratio = 0.5
+w_forceRef_time_ratio = 1.
 
 YAW_ROT_GAIN = 1.
 

--- a/python/mlp/demo_configs/common_solo.py
+++ b/python/mlp/demo_configs/common_solo.py
@@ -1,0 +1,71 @@
+try:
+    from solo_rbprm.solo import Robot
+except ImportError:
+    message = "ERROR: Cannot import solo-rbprm package.\n"
+    message += "Did you correctly installed it?\n"
+    message +="https://github.com/humanoid-path-planner/solo-rbprm"
+    raise ImportError(message)
+MASS = 2.5  # cannot retrieve it from urdf because the file is not parsed here ...
+MU = 0.9
+## weight and gains used by TSID
+IK_dt = 0.002
+fMin = 1.0  # minimum normal force
+fMax = 25.  # maximum normal force
+w_com = 1.0  # weight of center of mass task
+w_am =  2e-2
+w_am_track = 2e-2 # weight used for the tracking of the Angular momentum
+w_posture = 0.01  # weight of joint posture task
+w_rootOrientation = 1.  # weight of the root's orientation task
+w_eff = 1.0  # weight of the effector motion task
+kp_contact = 50.0  # proportional gain of contact constraint
+kp_com = 30.  # proportional gain of center of mass task
+kp_am = 20.
+kp_am_track = 20. # gain used for the tracking of the Angular momentum
+kp_posture = 10.  # proportional gain of joint posture task
+kp_rootOrientation = 5000.  # proportional gain of the root's orientation task
+kp_Eff = 100.  # proportional gain of the effectors motion task
+level_eff = 0
+level_com = 0
+level_posture = 1
+level_rootOrientation = 1
+level_am = 1
+
+# The weight of the force regularization task of each contact will start at w_forceRef_init when creating a new contact,
+# and then linearly reduce to w_forceRef_end over a time period of phase_duration * w_forceRef_time_ratio
+w_forceRef_init = 1.
+w_forceRef_end = 1e-5
+w_forceRef_time_ratio = 0.5
+
+YAW_ROT_GAIN = 1.
+
+IK_eff_size = Robot.dict_size.copy()
+PLOT_CIRCLE_RADIUS = 0.01 # radius of the circle used to display the contacts
+
+# phases duration
+DURATION_INIT = 1.  # Time to init the motion
+DURATION_FINAL = 1.  # Time to stop the robot
+DURATION_FINAL_SS = 1.
+DURATION_SS = 1.2
+DURATION_DS = 1.2
+DURATION_TS = 0.6
+DURATION_QS = 0.1
+DURATION_CONNECT_GOAL = 0.
+
+## Settings for end effectors :
+EFF_T_DELAY = 0.
+FEET_MAX_VEL = 0.7
+FEET_MAX_ANG_VEL = 1.5
+p_max = 0.05
+EFF_T_PREDEF = 0.
+
+GUIDE_STEP_SIZE = 0.3
+SL1M_USE_MIP = True
+SL1M_USE_INTERSECTION = False
+
+import numpy as np
+gain_vector = np.ones(12)
+masks_posture = np.zeros(12)
+for i in range(4):
+    masks_posture[2 + i * 3] = 1.  # knees
+
+IK_REFERENCE_CONFIG = np.array(Robot.referenceConfig)

--- a/python/mlp/demo_configs/common_solo.py
+++ b/python/mlp/demo_configs/common_solo.py
@@ -15,7 +15,7 @@ w_com = 1.0  # weight of center of mass task
 w_am =  2e-2
 w_am_track = 2e-2 # weight used for the tracking of the Angular momentum
 w_posture = 0.01  # weight of joint posture task
-w_rootOrientation = 1.  # weight of the root's orientation task
+w_rootOrientation = 0.1  # weight of the root's orientation task
 w_eff = 1.0  # weight of the effector motion task
 kp_contact = 50.0  # proportional gain of contact constraint
 kp_com = 30.  # proportional gain of center of mass task
@@ -27,7 +27,7 @@ kp_Eff = 100.  # proportional gain of the effectors motion task
 level_eff = 0
 level_com = 0
 level_posture = 1
-level_rootOrientation = 1
+level_rootOrientation = 0
 level_am = 1
 
 # The weight of the force regularization task of each contact will start at w_forceRef_init when creating a new contact,
@@ -40,6 +40,7 @@ YAW_ROT_GAIN = 1.
 
 IK_eff_size = Robot.dict_size.copy()
 PLOT_CIRCLE_RADIUS = 0.01 # radius of the circle used to display the contacts
+SOLVER_DT = 0.05  # time step used for centroidal methods
 
 # phases duration
 DURATION_INIT = 1.  # Time to init the motion
@@ -47,7 +48,7 @@ DURATION_FINAL = 1.  # Time to stop the robot
 DURATION_FINAL_SS = 1.
 DURATION_SS = 1.2
 DURATION_DS = 1.2
-DURATION_TS = 0.6
+DURATION_TS = 0.4
 DURATION_QS = 0.1
 DURATION_CONNECT_GOAL = 0.
 
@@ -58,9 +59,10 @@ FEET_MAX_ANG_VEL = 1.5
 p_max = 0.05
 EFF_T_PREDEF = 0.
 
-GUIDE_STEP_SIZE = 0.3
+GUIDE_STEP_SIZE = 0.5
 SL1M_USE_MIP = True
-SL1M_USE_INTERSECTION = False
+SL1M_USE_INTERSECTION = True
+SL1M_MAX_STEP = 10
 
 import numpy as np
 gain_vector = np.ones(12)

--- a/python/mlp/demo_configs/common_talos.py
+++ b/python/mlp/demo_configs/common_talos.py
@@ -63,6 +63,8 @@ FEET_MAX_VEL = 0.5  # maximal linear velocity of the effector, if the current du
 FEET_MAX_ANG_VEL = 1.5  # maximal angular velocity of the effectors
 p_max = 0.1  #setting used to compute the default height of the effector trajectory. end_effector/bezier_predef.py : computePosOffset()
 
+Robot.limbs_names = [Robot.rLegId, Robot.lLegId] # Remove the arms from the list of limbs used for contact creation
+
 import numpy as np
 gain_vector = np.array(  # gain vector for postural task
     [

--- a/python/mlp/demo_configs/solo_flatGround.py
+++ b/python/mlp/demo_configs/solo_flatGround.py
@@ -6,9 +6,9 @@ ENV_NAME = "multicontact/ground"
 # phases duration
 DURATION_INIT = 1.  # Time to init the motion
 DURATION_FINAL = 1.  # Time to stop the robot
-DURATION_TS = 0.4
+DURATION_TS = 0.5
 DURATION_QS = 0.1
-
+DURATION_CONNECT_GOAL = 2.
 USE_PLANNING_ROOT_ORIENTATION = True
 GUIDE_MAX_YAW = 0.5 # maximal yaw rotation difference between two discretization step
 

--- a/python/mlp/demo_configs/solo_flatGround.py
+++ b/python/mlp/demo_configs/solo_flatGround.py
@@ -6,8 +6,8 @@ ENV_NAME = "multicontact/ground"
 # phases duration
 DURATION_INIT = 1.  # Time to init the motion
 DURATION_FINAL = 1.  # Time to stop the robot
-DURATION_TS = 0.4
-DURATION_QS = 0.1
+DURATION_TS = 0.3
+DURATION_QS = 0.05
 DURATION_CONNECT_GOAL = 2.
 USE_PLANNING_ROOT_ORIENTATION = True
 GUIDE_MAX_YAW = 0.5 # maximal yaw rotation difference between two discretization step

--- a/python/mlp/demo_configs/solo_flatGround.py
+++ b/python/mlp/demo_configs/solo_flatGround.py
@@ -3,7 +3,11 @@ from .common_solo import *
 SCRIPT_PATH = "demos"
 ENV_NAME = "multicontact/ground"
 
-
+# phases duration
+DURATION_INIT = 1.  # Time to init the motion
+DURATION_FINAL = 1.  # Time to stop the robot
+DURATION_TS = 0.4
+DURATION_QS = 0.1
 
 USE_PLANNING_ROOT_ORIENTATION = True
 GUIDE_MAX_YAW = 0.5 # maximal yaw rotation difference between two discretization step

--- a/python/mlp/demo_configs/solo_flatGround.py
+++ b/python/mlp/demo_configs/solo_flatGround.py
@@ -1,0 +1,10 @@
+TIMEOPT_CONFIG_FILE = "cfg_softConstraints_solo.yaml"
+from .common_solo import *
+SCRIPT_PATH = "demos"
+ENV_NAME = "multicontact/ground"
+
+
+
+USE_PLANNING_ROOT_ORIENTATION = True
+GUIDE_MAX_YAW = 0.5 # maximal yaw rotation difference between two discretization step
+

--- a/python/mlp/demo_configs/solo_pallet.py
+++ b/python/mlp/demo_configs/solo_pallet.py
@@ -1,14 +1,15 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_solo.yaml"
 from .common_solo import *
 SCRIPT_PATH = "demos"
-ENV_NAME = "multicontact/ground"
+ENV_NAME = "ori/modular_palet_low"
 
 # phases duration
 DURATION_INIT = 1.  # Time to init the motion
 DURATION_FINAL = 1.  # Time to stop the robot
-DURATION_TS = 0.4
+DURATION_TS = 0.5
 DURATION_QS = 0.1
 DURATION_CONNECT_GOAL = 2.
 USE_PLANNING_ROOT_ORIENTATION = True
 GUIDE_MAX_YAW = 0.5 # maximal yaw rotation difference between two discretization step
+GUIDE_STEP_SIZE = 0.5
 

--- a/python/mlp/demo_configs/solo_slalom.py
+++ b/python/mlp/demo_configs/solo_slalom.py
@@ -1,14 +1,15 @@
 TIMEOPT_CONFIG_FILE = "cfg_softConstraints_solo.yaml"
 from .common_solo import *
 SCRIPT_PATH = "demos"
-ENV_NAME = "multicontact/ground"
+ENV_NAME = "multicontact/slalom_debris"
 
 # phases duration
 DURATION_INIT = 1.  # Time to init the motion
 DURATION_FINAL = 1.  # Time to stop the robot
-DURATION_TS = 0.4
+DURATION_TS = 0.5
 DURATION_QS = 0.1
 DURATION_CONNECT_GOAL = 2.
 USE_PLANNING_ROOT_ORIENTATION = True
 GUIDE_MAX_YAW = 0.5 # maximal yaw rotation difference between two discretization step
+GUIDE_STEP_SIZE = 0.5
 

--- a/python/mlp/end_effector/limb_rrt_optimized.py
+++ b/python/mlp/end_effector/limb_rrt_optimized.py
@@ -126,7 +126,11 @@ def generate_effector_trajectory_limb_rrt_optimized(cfg,
     t_middle = t_end - t_begin
     logger.info("t begin : %f", t_begin)
     logger.info("t end   : %f", t_end)
+    logger.info("q_t min : %f", q_t.min())
+    logger.info("q_t max   : %f", q_t.max())
     q_init = q_t(t_begin)
+    if t_end > q_t.max():
+        t_end = q_t.max()
     q_end = q_t(t_end)
     global current_limbRRT_id
     # compute new limb-rrt path if needed:

--- a/python/mlp/loco_planner.py
+++ b/python/mlp/loco_planner.py
@@ -33,6 +33,7 @@ class LocoPlanner:
         self.fullBody = None
         self.viewer = None
         self.gui = None
+        self.pin_robot = None
         # arrays used to store the cs after each iterations of the dynamic filter
         self.cs_com_iters = []
         self.cs_ref_iters = []
@@ -132,7 +133,7 @@ class LocoPlanner:
             self.cfg.w_am = self.cfg.w_am_track
             self.cfg.kp_am = self.cfg.kp_am_track
 
-        self.cs_wb, robot = generate_wholebody(self.cfg, self.cs_ref, self.fullBody, self.viewer)
+        self.cs_wb, self.pin_robot = generate_wholebody(self.cfg, self.cs_ref, self.fullBody, self.viewer)
         WholebodyOutputs.assertRequirements(self.cs_wb)
         WholebodyOutputs.assertWholebodyData(self.cs_wb, self.cfg)
         self.cs_wb_iters += [self.cs_wb]

--- a/python/mlp/loco_planner.py
+++ b/python/mlp/loco_planner.py
@@ -96,7 +96,7 @@ class LocoPlanner:
 
         if self.cfg.DISPLAY_COM_TRAJ:
             colors = [self.viewer.color.blue, self.viewer.color.green]
-            display_tools.displayCOMTrajectory(self.cs_com, self.gui, self.viewer.sceneName, self.cfg.DT_DISPLAY, colors)
+            display_tools.displayCOMTrajectory(self.cs_com, self.gui, self.viewer.sceneName, self.cfg.SOLVER_DT, colors)
         if self.cfg.PLOT_CENTROIDAL:
             plot.plotCOMTraj(self.cs_com, self.cfg.SOLVER_DT, " - iter " + str(iter_dynamic_filter))
             plot.plotAMTraj(self.cs_com, self.cfg.SOLVER_DT, " - iter " + str(iter_dynamic_filter))

--- a/python/mlp/loco_planner_reactive.py
+++ b/python/mlp/loco_planner_reactive.py
@@ -553,7 +553,7 @@ class LocoPlannerReactive(LocoPlanner):
                     cs_wb, last_q, last_v, last_phase, robot = self.compute_wholebody(
                         robot, cs_com, last_q, last_v, last_iter)
                     logger.info("-- Add a cs_wb to the queue")
-                    self.queue_qt.put([cs_wb.concatenateQtrajectories(), last_phase, last_iter])
+                    self.queue_qt.put([cs_wb.concatenateQtrajectories(), cs_wb.concatenateDQtrajectories(), last_phase, last_iter])
                 else:
                     timeout = True
                     logger.warning("Loop wholebody closed because pipe is empty since 10 seconds")
@@ -578,7 +578,7 @@ class LocoPlannerReactive(LocoPlanner):
         timeout = TIMEOUT_CONNECTIONS
         try:
             while not last_iter:
-                q_t, last_phase, last_iter = self.queue_qt.get(timeout=timeout)
+                q_t, dq_t, last_phase, last_iter = self.queue_qt.get(timeout=timeout)
                 timeout = 0.1
                 if last_phase:
                     self.set_last_phase(last_phase)

--- a/python/mlp/loco_planner_reactive.py
+++ b/python/mlp/loco_planner_reactive.py
@@ -79,6 +79,7 @@ class LocoPlannerReactive(LocoPlanner):
         cfg.TIME_SHIFT_COM = 0.
         self.previous_connect_goal = cfg.DURATION_CONNECT_GOAL
         cfg.DURATION_CONNECT_GOAL = 0.
+        self.TIMEOPT_CONFIG_FILE = cfg.TIMEOPT_CONFIG_FILE
         super().__init__(cfg)
         # Get the centroidal and wholebody methods selected in the configuraton file
         self.generate_centroidal, self.CentroidalInputs, self.CentroidalOutputs = self.cfg.get_centroidal_method()
@@ -331,11 +332,11 @@ class LocoPlannerReactive(LocoPlanner):
         if last_iter:
             # Set settings specific to the last iteration that need to connect exactly to the final goal position
             self.cfg.DURATION_CONNECT_GOAL = self.previous_connect_goal
-            self.cfg.TIMEOPT_CONFIG_FILE = "cfg_softConstraints_talos.yaml"
+            self.cfg.TIMEOPT_CONFIG_FILE = self.TIMEOPT_CONFIG_FILE
         else:
             # Set settings for the middle of the sequence: do not need to connect exactly to the goal
             self.cfg.DURATION_CONNECT_GOAL = 0.
-            self.cfg.TIMEOPT_CONFIG_FILE = "cfg_softConstraints_talos_lowgoal.yaml"
+            self.cfg.TIMEOPT_CONFIG_FILE = self.TIMEOPT_CONFIG_FILE.rstrip(".yaml") + "_lowgoal.yaml"
         if not self.CentroidalInputs.checkAndFillRequirements(cs, self.cfg, None):
             raise RuntimeError(
                 "The current contact sequence cannot be given as input to the centroidal method selected.")

--- a/python/mlp/utils/cs_tools.py
+++ b/python/mlp/utils/cs_tools.py
@@ -738,6 +738,8 @@ def setAllUninitializedContactModel(cs, Robot):
             if phase.contactPatch(eeName).contact_model.contact_type == ContactType.CONTACT_UNDEFINED:
                 if Robot.cType == "_3_DOF":
                     phase.contactPatch(eeName).contact_model.contact_type = ContactType.CONTACT_POINT
+                    phase.contactPatch(eeName).contact_model.contact_points_positions = \
+                        Robot.dict_offset[eeName].translation
                 elif Robot.cType == "_6_DOF":
                     phase.contactPatch(eeName).contact_model.contact_type = ContactType.CONTACT_PLANAR
                     phase.contactPatch(eeName).contact_model.contact_points_positions =\

--- a/python/mlp/utils/cs_tools.py
+++ b/python/mlp/utils/cs_tools.py
@@ -40,6 +40,8 @@ def createPhaseFromConfig(fb, q, limbsInContact, t_init = -1):
         eeName = fb.dict_limb_joint[limb]
         q_j = fb.getJointPosition(eeName)
         placement = SE3FromConfig(q_j)
+        if fb.cType == '_3_DOF':
+            placement.rotation = np.identity(3) # FIXME:  use contact normal instead of identity, but it's unknown here
         patch = ContactPatch(placement)  # TODO set friction / other parameters here
         phase.addContact(eeName, patch)
     return phase

--- a/python/mlp/utils/cs_tools.py
+++ b/python/mlp/utils/cs_tools.py
@@ -26,8 +26,8 @@ def createPhaseFromConfig(fb, q, limbsInContact, t_init = -1):
     phase.q_init = np.array(q)
     fb.setCurrentConfig(q)
     com = np.array(fb.getCenterOfMass())
-    if t_init > 0:
-        phase.timeInitial = 0.
+    if t_init >= 0:
+        phase.timeInitial = t_init
     phase.c_init = com.copy()
     phase.c_final = com.copy()
     if  fb.client.robot.getDimensionExtraConfigSpace() >= 6 and len(q) == fb.getConfigSize():

--- a/python/mlp/utils/cs_tools.py
+++ b/python/mlp/utils/cs_tools.py
@@ -148,7 +148,7 @@ def setFinalState(cs, com=None, q=None):
     phase.c_final = com
 
 
-def walk(fb, cs, distance, stepLength, gait, duration_ss = -1 , duration_ds = -1):
+def walk(fb, cs, distance, stepLength, gait, duration_ss = -1 , duration_ds = -1, first_half_step=True):
     """
     Generate a walking motion from the last phase in the contact sequence.
     The contacts will be moved in the order of the 'gait' list. With the first one move only of half the stepLength
@@ -166,7 +166,7 @@ def walk(fb, cs, distance, stepLength, gait, duration_ss = -1 , duration_ds = -1
     for limb in gait:
         eeName = fb.dict_limb_joint[limb]
         assert prev_phase.isEffectorInContact(eeName), "All limbs in gait should be in contact in the first phase"
-    isFirst = True
+    isFirst = first_half_step
     reached = False
     firstContactReachedGoal = False
     remainingDistance = distance
@@ -179,7 +179,7 @@ def walk(fb, cs, distance, stepLength, gait, duration_ss = -1 , duration_ds = -1
                 isFirst = False
             else:
                 length = stepLength
-            if k == 0:
+            if k == 0 and first_half_step:
                 if length > (remainingDistance + stepLength / 2.):
                     length = remainingDistance + stepLength / 2.
                     firstContactReachedGoal = True
@@ -191,7 +191,7 @@ def walk(fb, cs, distance, stepLength, gait, duration_ss = -1 , duration_ds = -1
             transform.translation = np.array([length, 0, 0])
             cs.moveEffectorOf(eeName, transform, duration_ds, duration_ss)
         remainingDistance -= stepLength
-    if not firstContactReachedGoal:
+    if first_half_step and not firstContactReachedGoal:
         transform = SE3.Identity()
         #print("last length = ", stepLength)
         transform.translation  = np.array([stepLength / 2., 0, 0])

--- a/python/mlp/utils/plot.py
+++ b/python/mlp/utils/plot.py
@@ -418,7 +418,7 @@ def plotKneeTorque(cs, dt, kneeIds, offset):
     plt.suptitle("Knee torque")
     ax = fig.gca()
     ax.set_xlabel('time (s)')
-    ax.set_ylabel("Torque")
+    ax.set_ylabel("Nm")
     ax.yaxis.grid()
     tau, timeline = discretizeCurve(cs.concatenateTauTrajectories(), dt)
     for k, name in enumerate(kneeIds.keys()):

--- a/python/mlp/utils/util.py
+++ b/python/mlp/utils/util.py
@@ -205,8 +205,15 @@ def computeContactNormal(placement):
     contactNormal = placement.rotation @ z_up
     return contactNormal
 
-
-
+def rotationFromNormal(n):
+    """
+    return a rotation matrix corresponding to the given contact normal
+    :param n: the normal of the surface (as a numpy array)
+    :return: a rotation matrix
+    """
+    z_up = np.array([0., 0., 1.])
+    q = Quaternion.FromTwoVectors(z_up, n)
+    return q.matrix()
 
 def discretizeCurve(curve,dt):
     """

--- a/python/mlp/viewer/display_tools.py
+++ b/python/mlp/viewer/display_tools.py
@@ -252,7 +252,7 @@ def displaySE3Traj(traj, gui, sceneName, name, color, time_interval, offset=SE3.
         gui.addToGroup(name, sceneName)
         gui.refresh()
 
-def displayEffectorTrajectories(cs, viewer, Robot, suffixe = "", colorAlpha = 1):
+def displayEffectorTrajectories(cs, viewer, Robot, suffixe = "", colorAlpha = 1, applyOffset = False):
     """
     Display all the effector trajectories stored in the given ContactSequence.
     With colors for each effectors defined in Robot.dict_limb_color_traj
@@ -268,9 +268,13 @@ def displayEffectorTrajectories(cs, viewer, Robot, suffixe = "", colorAlpha = 1)
             if phase.effectorHaveAtrajectory(eeName):
                 color = Robot.dict_limb_color_traj[eeName]
                 color[-1] = colorAlpha
+                if applyOffset:
+                    offset = -Robot.dict_offset[eeName]
+                else:
+                    offset = SE3.Identity()
                 displaySE3Traj(phase.effectorTrajectory(eeName), viewer.client.gui, viewer.sceneName,
                                  eeName + "_traj_"+ suffixe + str(pid), color,
-                                 [phase.timeInitial, phase.timeFinal], Robot.dict_offset[eeName])
+                                 [phase.timeInitial, phase.timeFinal], offset)
 
 def displayWBconfig(viewer, q_matrix):
     """

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -746,4 +746,4 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None, robot=None,
     logger.info("Desired COM Position %s", cs.contactPhases[-1].c_final)
     if queue_qt:
         queue_qt.put([phase.q_t.curve_at_index(phase.q_t.num_curves() - 1), None, True])
-    return cs, robot
+    return cs, pinRobot

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -676,6 +676,7 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None, robot=None,
                         # save the first q_t trajectory computed, for limb-rrt
                         first_q_t = phase.q_t
                     logger.warning("Phase %d not valid at t = %f", pid, t_invalid)
+                    logger.info("First invalid q : %s", phase.q_t(t_invalid))
                     if t_invalid <= (phase.timeInitial + cfg.EFF_T_PREDEF) \
                             or t_invalid >= (phase.timeFinal - cfg.EFF_T_PREDEF):
                         logger.error("Motion is invalid during predefined phases, cannot change this.")

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -213,7 +213,10 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None, robot=None,
             phase.q_t.append(q, t)
             #phase.root_t.append(SE3FromConfig(q), t)
         if queue_qt:
-            queue_qt.put([phase.q_t.curve_at_index(phase.q_t.num_curves()-1), None, False])
+            queue_qt.put([phase.q_t.curve_at_index(phase.q_t.num_curves()-1),
+                          phase.dq_t.curve_at_index(phase.dq_t.num_curves()-1),
+                          None,
+                          False])
 
     def appendJointsDerivatives(first_iter_for_phase=False):
         if first_iter_for_phase:
@@ -303,9 +306,9 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None, robot=None,
 
 
     def storeData(first_iter_for_phase = False):
-        appendJointsValues(first_iter_for_phase)
         if cfg.IK_store_joints_derivatives:
             appendJointsDerivatives(first_iter_for_phase)
+        appendJointsValues(first_iter_for_phase)
         if cfg.IK_store_joints_torque:
             appendTorques(first_iter_for_phase)
         if cfg.IK_store_centroidal:

--- a/python/mlp/wholebody/tsid.py
+++ b/python/mlp/wholebody/tsid.py
@@ -474,6 +474,20 @@ def generate_wholebody_tsid(cfg, cs_ref, fullBody=None, viewer=None, robot=None,
     usedEffectors = cs.getAllEffectorsInContact()
     dic_effectors_tasks = createEffectorTasksDic(cfg, usedEffectors, robot)
 
+    # Add bounds tasks if required:
+    if cfg.w_torque_bounds > 0.:
+        tau_max = cfg.scaling_torque_bounds*robot.model().effortLimit[-robot.na:]
+        tau_min = -tau_max
+        actuationBoundsTask = tsid.TaskActuationBounds("task-actuation-bounds", robot)
+        actuationBoundsTask.setBounds(tau_min, tau_max)
+        invdyn.addActuationTask(actuationBoundsTask, cfg.w_torque_bounds, 0, 0.0)
+    if cfg.w_joint_bounds > 0.:
+        jointBoundsTask = tsid.TaskJointBounds("task-joint-bounds", robot, cfg.IK_dt)
+        v_max = cfg.scaling_vel_bounds * robot.model().velocityLimit[-robot.na:]
+        v_min = -v_max
+        print("v_max : ", v_max)
+        jointBoundsTask.setVelocityBounds(v_min, v_max)
+        invdyn.addMotionTask(jointBoundsTask, cfg.w_joint_bounds, 0, 0.0)
 
     solver = tsid.SolverHQuadProg("qp solver")
     solver.resize(invdyn.nVar, invdyn.nEq, invdyn.nIn)


### PR DESCRIPTION
## Main changes

* Major changes in `contact_sequence/sl1m.py` to be able to deal with MIP version of SL1M
* Add an option `SL1M_USE_MIP` in the config file to use either version of SL1M

## Other changes

### Fix related to quadrupedal

* Fix limb-rrt when `eff_predef = 0`
* `createPhaseFromConfig` set contact rotation to Identity when using contact point
* Correctly initialize contact_model.contact_points_positions when using contact points

### Reactive planning

* Remove all hardcoded occurence specfic to talos, make it generic to any robot
* Update to change of API in SL1M
* Use a time horizon for SL1M call
* Add pybullet integration
* queue_qt now also store joint velocity


### Scenario

* Add common file for Solo robot
* Add demo with solo
    * flat_ground
    * slalom
    * pallet
* Update ANYmal config file to the changes in SL1M quadrupedal

### Other

* Correctly set initial contact phase time in `createPhaseFromConfig`
* Correctly display the CoM trajectory in the viewer with the same discretization step as the solver
* TSID: add spport of torque and velocity bounds


